### PR TITLE
Shell folders compatibility improvements

### DIFF
--- a/src/ManagedShell.Common/Helpers/IconHelper.cs
+++ b/src/ManagedShell.Common/Helpers/IconHelper.cs
@@ -71,6 +71,11 @@ namespace ManagedShell.Common.Helpers
             return GetIcon(fileName, size);
         }
 
+        public static IntPtr GetIconByPidl(IntPtr pidl, IconSize size)
+        {
+            return GetIcon(pidl, size);
+        }
+
         private static IntPtr GetIcon(string filename, IconSize size)
         {
             lock (ComLock)
@@ -91,6 +96,27 @@ namespace ManagedShell.Common.Helpers
                     {
                         SHGetFileInfo(filename, FILE_ATTRIBUTE_NORMAL, ref shinfo, (uint)Marshal.SizeOf(shinfo), (uint)(SHGFI.UseFileAttributes | SHGFI.SysIconIndex));
                     }
+
+                    return getFromImageList(shinfo.iIcon, size);
+                }
+                catch
+                {
+                    return IntPtr.Zero;
+                }
+            }
+        }
+
+        private static IntPtr GetIcon(IntPtr pidl, IconSize size)
+        {
+            lock (ComLock)
+            {
+                try
+                {
+                    SHFILEINFO shinfo = new SHFILEINFO();
+                    shinfo.szDisplayName = string.Empty;
+                    shinfo.szTypeName = string.Empty;
+
+                    SHGetFileInfo(pidl, FILE_ATTRIBUTE_NORMAL, ref shinfo, (uint)Marshal.SizeOf(shinfo), (uint)(SHGFI.PIDL | SHGFI.SysIconIndex));
 
                     return getFromImageList(shinfo.iIcon, size);
                 }

--- a/src/ManagedShell.Common/Helpers/IconImageConverter.cs
+++ b/src/ManagedShell.Common/Helpers/IconImageConverter.cs
@@ -26,6 +26,19 @@ namespace ManagedShell.Common.Helpers
         }
 
         /// <summary>
+        /// Retrieves the Icon for the absolute PIDL as an ImageSource
+        /// </summary>
+        /// <param name="pidl">The PIDL to query the Icon for.</param>
+        /// <param name="size">0 = 32px, 1 = 16px, 2 = 48px</param>
+        /// <returns>The icon as an ImageSource, otherwise a default image.</returns>
+        public static ImageSource GetImageFromAssociatedIcon(IntPtr pidl, IconSize size)
+        {
+            IntPtr hIcon = IconHelper.GetIconByPidl(pidl, size);
+
+            return GetImageFromHIcon(hIcon);
+        }
+
+        /// <summary>
         /// Retrieves the Icon for the Handle provided as an ImageSource.
         /// </summary>
         /// <param name="hBitmap">The icon's handle (HBITMAP).</param>

--- a/src/ManagedShell.Interop/NativeMethods.Shell32.cs
+++ b/src/ManagedShell.Interop/NativeMethods.Shell32.cs
@@ -128,6 +128,9 @@ namespace ManagedShell.Interop
         [DllImport(Shell32_DllName, CharSet = CharSet.Unicode)]
         public static extern IntPtr SHGetFileInfo(string pszPath, uint dwFileAttributes, ref SHFILEINFO psfi, uint cbSizeFileInfo, uint uFlags);
 
+        [DllImport(Shell32_DllName, CharSet = CharSet.Unicode)]
+        public static extern IntPtr SHGetFileInfo(IntPtr pszPath, uint dwFileAttributes, ref SHFILEINFO psfi, uint cbSizeFileInfo, uint uFlags);
+
         [DllImport(Shell32_DllName, CharSet = CharSet.Auto)]
         public static extern bool ShellExecuteEx(ref SHELLEXECUTEINFO lpExecInfo);
 

--- a/src/ManagedShell.ShellFolders/Interop.cs
+++ b/src/ManagedShell.ShellFolders/Interop.cs
@@ -50,6 +50,9 @@ namespace ManagedShell.ShellFolders
         [DllImport("shell32.dll")]
         public static extern int SHGetIDListFromObject(IShellItem punk, out IntPtr ppidl);
 
+        [DllImport("shell32.dll")]
+        public static extern int SHGetIDListFromObject(IShellFolder punk, out IntPtr ppidl);
+
         [DllImport("shell32.dll", CharSet = CharSet.Unicode, PreserveSig = false)]
         public static extern void SHCreateItemFromParsingName(
             [In][MarshalAs(UnmanagedType.LPWStr)] string pszPath,
@@ -62,6 +65,12 @@ namespace ManagedShell.ShellFolders
             [In] IntPtr pidl,
             [In][MarshalAs(UnmanagedType.LPStruct)] Guid riid,
             [Out][MarshalAs(UnmanagedType.Interface, IidParameterIndex = 2)] out IShellItemImageFactory ppv);
+
+        [DllImport("shell32.dll", CharSet = CharSet.Unicode, PreserveSig = false)]
+        public static extern void SHCreateItemFromIDList(
+            [In] IntPtr pidl,
+            [In][MarshalAs(UnmanagedType.LPStruct)] Guid riid,
+            [Out][MarshalAs(UnmanagedType.Interface, IidParameterIndex = 2)] out IShellItem ppv);
 
         [DllImport("shell32.dll", CharSet = CharSet.Unicode, PreserveSig = false)]
         public static extern void SHCreateItemWithParent(

--- a/src/ManagedShell.ShellFolders/Interop.cs
+++ b/src/ManagedShell.ShellFolders/Interop.cs
@@ -91,6 +91,14 @@ namespace ManagedShell.ShellFolders
             uint uIDNewItem,
             [MarshalAs(UnmanagedType.LPTStr)]
             string lpNewItem);
+        
+        [DllImport("user32",
+            SetLastError = true,
+            CharSet = CharSet.Auto)]
+        public static extern bool SetMenuDefaultItem(
+            IntPtr hMenu,
+            uint uItem,
+            uint fByPos);
 
         // Retrieves a handle to the drop-down menu or submenu activated by the specified menu item
         [DllImport("user32",

--- a/src/ManagedShell.ShellFolders/ShellFolder.cs
+++ b/src/ManagedShell.ShellFolders/ShellFolder.cs
@@ -294,7 +294,7 @@ namespace ManagedShell.ShellFolders
 
             if (desktop.BindToObject(folderPidl, IntPtr.Zero, ref guid, out _shellFolderPtr) == NativeMethods.S_OK)
             {
-                Marshal.FinalReleaseComObject(desktop);
+                Marshal.ReleaseComObject(desktop);
                 return (IShellFolder)Marshal.GetTypedObjectForIUnknown(_shellFolderPtr, typeof(IShellFolder));
             }
 
@@ -404,7 +404,7 @@ namespace ManagedShell.ShellFolders
 
             if (_shellFolder != null)
             {
-                Marshal.FinalReleaseComObject(_shellFolder);
+                Marshal.ReleaseComObject(_shellFolder);
                 _shellFolder = null;
             }
 

--- a/src/ManagedShell.ShellFolders/ShellMenuCommandBuilder.cs
+++ b/src/ManagedShell.ShellFolders/ShellMenuCommandBuilder.cs
@@ -6,6 +6,7 @@ namespace ManagedShell.ShellFolders
     public class ShellMenuCommandBuilder
     {
         public List<ShellMenuCommand> Commands = new List<ShellMenuCommand>();
+        public uint DefaultItemUID;
 
         public void AddCommand(ShellMenuCommand command)
         {


### PR DESCRIPTION
- Requests to load the desktop folder now get it using SHGetDesktopFolder, which combines user and common desktop, and fixes loading that folder on Windows 7
- Added icon fallback to SHGetFileInfo for Windows Server
- Fall back to root shell item if unable to get parent of provided item
- Fixed use after free caused by desktop changes
- Added ability to define a custom default item in context menus
- Added ability to optionally override the open action for navigable folders