### PR TITLE
More shell folders fixes

### DIFF
--- a/src/ManagedShell.Interop/KnownFolders.cs
+++ b/src/ManagedShell.Interop/KnownFolders.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace ManagedShell.Interop
+{
+    /// <summary>
+    /// Standard folders registered with the system that aren't provided by Environment.SpecialFolder.
+    /// </summary>
+    public enum KnownFolder
+    {
+        Contacts,
+        Downloads,
+        Links,
+        SavedGames,
+        SavedSearches
+    }
+    
+    /// <summary>
+    /// Class containing methods to retrieve specific file system paths that aren't provided by Environment.SpecialFolder.
+    /// </summary>
+    public static class KnownFolders
+    {
+        private static readonly string[] _knownFolderGuids = {
+            "{56784854-C6CB-462B-8169-88E350ACB882}", // Contacts
+            "{374DE290-123F-4565-9164-39C4925E467B}", // Downloads
+            "{BFB9D5E0-C6A9-404C-B2B2-AE6DB6AF4968}", // Links
+            "{4C5C32FF-BB9D-43B0-B5B4-2D72E54EAAA4}", // SavedGames
+            "{7D1D3A04-DEBB-4115-95CF-2F29DA2920DA}" // SavedSearches
+        };
+
+        /// <summary>
+        /// Gets the current path to the specified known folder as currently configured. This does
+        /// not require the folder to exist.
+        /// </summary>
+        /// <param name="knownFolder">The known folder which current path will be returned.</param>
+        /// <returns>The default path of the known folder, or an empty string if the path couldn't be retrieved.</returns>
+        public static string GetPath(KnownFolder knownFolder)
+        {
+            return GetPath(knownFolder, NativeMethods.KnownFolderFlags.DontVerify);
+        }
+
+        /// <summary>
+        /// Gets the current path to the specified known folder as currently configured.
+        /// </summary>
+        /// <param name="knownFolder">The known folder which current path will be returned.</param>
+        /// <param name="flags">The known folder flags to use.</param>
+        /// <returns>The default path of the known folder, or an empty string if the path couldn't be retrieved.</returns>
+        public static string GetPath(KnownFolder knownFolder, NativeMethods.KnownFolderFlags flags)
+        {
+            return GetPath(knownFolder, flags, false);
+        }
+
+        /// <summary>
+        /// Gets the current path to the specified known folder as currently configured.
+        /// </summary>
+        /// <param name="knownFolder">The known folder which current path will be returned.</param>
+        /// <param name="flags">The known folder flags to use.</param>
+        /// <param name="defaultUser">Specifies if the paths of the default user (user profile
+        ///     template) will be used. This requires administrative rights.</param>
+        /// <returns>The default path of the known folder, or an empty string if the path couldn't be retrieved.</returns>
+        public static string GetPath(KnownFolder knownFolder, NativeMethods.KnownFolderFlags flags,
+            bool defaultUser)
+        {
+            int result = NativeMethods.SHGetKnownFolderPath(new Guid(_knownFolderGuids[(int)knownFolder]),
+                (uint)flags, new IntPtr(defaultUser ? -1 : 0), out IntPtr outPath);
+            
+            if (result >= 0)
+            {
+                return Marshal.PtrToStringUni(outPath);
+            }
+
+            return string.Empty;
+        }
+    }
+}

--- a/src/ManagedShell.Interop/NativeMethods.Shell32.cs
+++ b/src/ManagedShell.Interop/NativeMethods.Shell32.cs
@@ -648,6 +648,7 @@ namespace ManagedShell.Interop
         [Flags]
         public enum KnownFolderFlags : uint
         {
+            None = 0,
             SimpleIDList = 0x00000100,
             NotParentRelative = 0x00000200,
             DefaultPath = 0x00000400,

--- a/src/ManagedShell.Interop/NativeMethods.Shell32.cs
+++ b/src/ManagedShell.Interop/NativeMethods.Shell32.cs
@@ -634,10 +634,30 @@ namespace ManagedShell.Interop
         };
 
         [DllImport(Shell32_DllName, EntryPoint = "#727")]
-        public extern static int SHGetImageList(
+        public static extern int SHGetImageList(
             int iImageList,
             ref Guid riid,
             out IImageList ppv
             );
+
+        [DllImport(Shell32_DllName)]
+        public static extern int SHGetKnownFolderPath(
+            [MarshalAs(UnmanagedType.LPStruct)] Guid rfid, uint dwFlags, IntPtr hToken,
+            out IntPtr ppszPath);
+
+        [Flags]
+        public enum KnownFolderFlags : uint
+        {
+            SimpleIDList = 0x00000100,
+            NotParentRelative = 0x00000200,
+            DefaultPath = 0x00000400,
+            Init = 0x00000800,
+            NoAlias = 0x00001000,
+            DontUnexpand = 0x00002000,
+            DontVerify = 0x00004000,
+            Create = 0x00008000,
+            NoAppcontainerRedirection = 0x00010000,
+            AliasOnly = 0x80000000
+        }
     }
 }

--- a/src/ManagedShell.ShellFolders/Enums/ShellFolderPath.cs
+++ b/src/ManagedShell.ShellFolders/Enums/ShellFolderPath.cs
@@ -1,0 +1,16 @@
+﻿namespace ManagedShell.ShellFolders.Enums
+{
+    public class ShellFolderPath
+    {
+        private ShellFolderPath(string value)
+        {
+            Value = value;
+        }
+
+        public string Value { get; set; }
+
+        public static ShellFolderPath ComputerFolder => new ShellFolderPath("::{20D04FE0-3AEA-1069-A2D8-08002B30309D}");
+        public static ShellFolderPath ControlPanelFolder => new ShellFolderPath("::{21EC2020-3AEA-1069-A2DD-08002B30309D}");
+        public static ShellFolderPath RecycleBinFolder => new ShellFolderPath("::{645FF040-5081-101B-9F08-00AA002F954E}");
+    }
+}

--- a/src/ManagedShell.ShellFolders/ShellContextMenu.cs
+++ b/src/ManagedShell.ShellFolders/ShellContextMenu.cs
@@ -160,7 +160,7 @@ namespace ManagedShell.ShellFolders
             invoke.cbSize = Interop.cbInvokeCommand;
             invoke.lpVerb = (IntPtr)cmd;
             invoke.lpVerbW = (IntPtr)cmd;
-            invoke.fMask = CMIC.ASYNCOK | CMIC.UNICODE | CMIC.PTINVOKE |
+            invoke.fMask = CMIC.ASYNCOK | CMIC.FLAG_LOG_USAGE | CMIC.UNICODE | CMIC.PTINVOKE |
                 ((Control.ModifierKeys & Keys.Control) != 0 ? CMIC.CONTROL_DOWN : 0) |
                 ((Control.ModifierKeys & Keys.Shift) != 0 ? CMIC.SHIFT_DOWN : 0);
             invoke.ptInvoke = new NativeMethods.POINT(ptInvoke.X, ptInvoke.Y);

--- a/src/ManagedShell.ShellFolders/ShellFolder.cs
+++ b/src/ManagedShell.ShellFolders/ShellFolder.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -76,9 +77,27 @@ namespace ManagedShell.ShellFolders
                 _shellItem = GetShellItem(parsingName);
             }
 
-            if (_shellItem != null && IsFileSystem)
+            if (_shellItem != null && IsFileSystem && IsFolder)
             {
-                _changeWatcher = new ChangeWatcher(Path, ChangedEventHandler, CreatedEventHandler, DeletedEventHandler, RenamedEventHandler);
+                List<string> watchList = new List<string>
+                {
+                    Path
+                };
+
+                if (IsDesktop)
+                {
+                    // The Desktop combines user and common desktop directories, so we need to watch both for changes.
+                    
+                    string publicDesktopPath = Environment.GetFolderPath(
+                        Environment.SpecialFolder.CommonDesktopDirectory, Environment.SpecialFolderOption.DoNotVerify);
+
+                    if (!string.IsNullOrEmpty(publicDesktopPath))
+                    {
+                        watchList.Add(publicDesktopPath);
+                    }
+                }
+                
+                _changeWatcher = new ChangeWatcher(watchList, ChangedEventHandler, CreatedEventHandler, DeletedEventHandler, RenamedEventHandler);
             }
         }
 


### PR DESCRIPTION
- Allow `ChangeWatcher` to watch multiple folders, use for both desktop folders
- Simplify and improve context menu handlers
- Add methods to get known folders that `Environment.SpecialFolder` doesn't provide