### PR TITLE
Misc fixes

### DIFF
--- a/.github/workflows/managedshell.yml
+++ b/.github/workflows/managedshell.yml
@@ -29,7 +29,7 @@ jobs:
       uses: dotnet/nbgv@v0.4.0
 
     - name: Build
-      run: dotnet build $env:project -c $env:config
+      run: dotnet build $env:project -c $env:config --disable-parallel
       env:
         config: ${{ matrix.buildconfig }}
 

--- a/src/ManagedShell.Interop/NativeMethods.User32.cs
+++ b/src/ManagedShell.Interop/NativeMethods.User32.cs
@@ -307,6 +307,9 @@ namespace ManagedShell.Interop
         public static extern IntPtr GetClassLongPtr(IntPtr handle, int longClass);
 
         [DllImport(User32_DllName)]
+        public static extern bool AllowSetForegroundWindow(uint procId);
+
+        [DllImport(User32_DllName)]
         public static extern bool SetForegroundWindow(IntPtr hWnd);
 
         [DllImport(User32_DllName)]

--- a/src/ManagedShell.WindowsTray/SafeNotifyIconData.cs
+++ b/src/ManagedShell.WindowsTray/SafeNotifyIconData.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using ManagedShell.Common.Logging;
 using static ManagedShell.Interop.NativeMethods;
 
 namespace ManagedShell.WindowsTray
@@ -30,7 +31,16 @@ namespace ManagedShell.WindowsTray
             uID = nid.uID;
             uFlags = nid.uFlags;
             uCallbackMessage = nid.uCallbackMessage;
-            hIcon = (IntPtr)nid.hIcon;
+
+            try
+            {
+                hIcon = (IntPtr)nid.hIcon;
+            }
+            catch (Exception e)
+            {
+                ShellLogger.Error($"SafeNotifyIconData: Unable to convert icon handle: {e.Message}");
+            }
+            
             szTip = nid.szTip;
             dwState = nid.dwState;
             dwStateMask = nid.dwStateMask;


### PR DESCRIPTION
- Fix `SearchHelper` specifying invalid column names in Windows 7 and 8
- Handle potential 32-bit overflow in the tray
- Fix notify icon focus issue and remove hack (cairoshell/cairoshell#498)
- Split notify icon mousedown and mouseup events