### PR TITLE
Add context menu dark mode support for 1903-20H2

### DIFF
--- a/src/ManagedShell.Common/Helpers/EnvironmentHelper.cs
+++ b/src/ManagedShell.Common/Helpers/EnvironmentHelper.cs
@@ -100,6 +100,11 @@ namespace ManagedShell.Common.Helpers
         {
             get
             {
+                if (IsServerCore)
+                {
+                    return false;
+                }
+                
                 if (osVersionMajor == 0)
                 {
                     getOSVersion();

--- a/src/ManagedShell.Common/Helpers/EnvironmentHelper.cs
+++ b/src/ManagedShell.Common/Helpers/EnvironmentHelper.cs
@@ -96,6 +96,20 @@ namespace ManagedShell.Common.Helpers
             }
         }
 
+        public static bool IsWindows10DarkModeSupported
+        {
+            get
+            {
+                if (osVersionMajor == 0)
+                {
+                    getOSVersion();
+                }
+
+                // This has an upper-bound due to the volatility of the undocumented dark mode API
+                return (osVersionMajor >= 10 && osVersionBuild >= 18362 && osVersionBuild <= 19042);
+            }
+        }
+
         private static bool? isAppConfiguredAsShell;
 
         /// <summary>

--- a/src/ManagedShell.Common/Helpers/WindowHelper.cs
+++ b/src/ManagedShell.Common/Helpers/WindowHelper.cs
@@ -167,5 +167,15 @@ namespace ManagedShell.Common.Helpers
                 Marshal.FreeHGlobal(accentPtr);
             }
         }
+
+        public static bool SetDarkModePreference(PreferredAppMode mode)
+        {
+            if (EnvironmentHelper.IsWindows10DarkModeSupported)
+            {
+                return SetPreferredAppMode(mode);
+            }
+
+            return false;
+        }
     }
 }

--- a/src/ManagedShell.Interop/NativeMethods.UxTheme.cs
+++ b/src/ManagedShell.Interop/NativeMethods.UxTheme.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace ManagedShell.Interop
+{
+    public partial class NativeMethods
+    {
+        // Undocumented dark mode API for 1903 and later
+        // https://github.com/ysc3839/win32-darkmode
+        
+        public enum PreferredAppMode
+        {
+            Default,
+            AllowDark,
+            ForceDark,
+            ForceLight,
+            Max
+        };
+
+        [DllImport("uxtheme.dll", EntryPoint = "#135")]
+        public static extern bool SetPreferredAppMode(PreferredAppMode mode);
+
+        [DllImport("uxtheme.dll", EntryPoint = "#133")]
+        public static extern bool AllowDarkModeForWindow(IntPtr hWnd, bool allow);
+    }
+}

--- a/src/ManagedShell.ShellFolders/ShellFolderContextMenu.cs
+++ b/src/ManagedShell.ShellFolders/ShellFolderContextMenu.cs
@@ -3,6 +3,7 @@ using System.Drawing;
 using System.Windows.Forms;
 using ManagedShell.Common.Helpers;
 using ManagedShell.Common.Logging;
+using ManagedShell.Interop;
 using ManagedShell.ShellFolders.Enums;
 
 namespace ManagedShell.ShellFolders
@@ -79,6 +80,11 @@ namespace ManagedShell.ShellFolders
         private void ShowMenu(ShellFolder folder, IntPtr contextMenu)
         {
             CreateHandle(new CreateParams());
+
+            if (EnvironmentHelper.IsWindows10DarkModeSupported)
+            {
+                NativeMethods.AllowDarkModeForWindow(Handle, true);
+            }
 
             uint selected = Interop.TrackPopupMenuEx(
                 contextMenu,

--- a/src/ManagedShell.ShellFolders/ShellItemContextMenu.cs
+++ b/src/ManagedShell.ShellFolders/ShellItemContextMenu.cs
@@ -18,7 +18,10 @@ namespace ManagedShell.ShellFolders
         public ShellItemContextMenu(ShellItem[] files, ShellFolder parentFolder, IntPtr hwndOwner, ItemSelectAction itemSelected, bool isInteractive) : this(files, parentFolder, hwndOwner, itemSelected, isInteractive, new ShellMenuCommandBuilder(), new ShellMenuCommandBuilder())
         { }
 
-        public ShellItemContextMenu(ShellItem[] files, ShellFolder parentFolder, IntPtr hwndOwner, ItemSelectAction itemSelected, bool isInteractive, ShellMenuCommandBuilder preBuilder, ShellMenuCommandBuilder postBuilder)
+        public ShellItemContextMenu(ShellItem[] files, ShellFolder parentFolder, IntPtr hwndOwner, ItemSelectAction itemSelected, bool isInteractive, ShellMenuCommandBuilder preBuilder, ShellMenuCommandBuilder postBuilder) : this(files, parentFolder, hwndOwner, itemSelected, isInteractive, true, preBuilder, postBuilder)
+        { }
+
+        public ShellItemContextMenu(ShellItem[] files, ShellFolder parentFolder, IntPtr hwndOwner, ItemSelectAction itemSelected, bool isInteractive, bool canRename, ShellMenuCommandBuilder preBuilder, ShellMenuCommandBuilder postBuilder)
         {
             if (files == null || files.Length < 1)
             {
@@ -32,7 +35,7 @@ namespace ManagedShell.ShellFolders
 
                 this.itemSelected = itemSelected;
 
-                SetupContextMenu(files, parentFolder, hwndOwner, isInteractive, preBuilder, postBuilder);
+                SetupContextMenu(files, parentFolder, hwndOwner, isInteractive, canRename, preBuilder, postBuilder);
             }
         }
 
@@ -58,7 +61,7 @@ namespace ManagedShell.ShellFolders
             return numAdded;
         }
 
-        private void SetupContextMenu(ShellItem[] files, ShellFolder parentFolder, IntPtr hwndOwner, bool isInteractive, ShellMenuCommandBuilder preBuilder, ShellMenuCommandBuilder postBuilder)
+        private void SetupContextMenu(ShellItem[] files, ShellFolder parentFolder, IntPtr hwndOwner, bool isInteractive, bool canRename, ShellMenuCommandBuilder preBuilder, ShellMenuCommandBuilder postBuilder)
         {
             try
             {
@@ -69,8 +72,12 @@ namespace ManagedShell.ShellFolders
 
                     CMF flags = CMF.EXPLORE |
                         CMF.ITEMMENU |
-                        CMF.CANRENAME |
                         ((Control.ModifierKeys & Keys.Shift) != 0 ? CMF.EXTENDEDVERBS : 0);
+
+                    if (canRename)
+                    {
+                        flags |= CMF.CANRENAME;
+                    }
 
                     if (!isInteractive)
                     {
@@ -158,6 +165,11 @@ namespace ManagedShell.ShellFolders
         private void ShowMenu(ShellItem[] files, bool allFolders)
         {
             CreateHandle(new CreateParams());
+
+            if (EnvironmentHelper.IsWindows10DarkModeSupported)
+            {
+                NativeMethods.AllowDarkModeForWindow(Handle, true);
+            }
 
             uint selected = Interop.TrackPopupMenuEx(
                 nativeMenuPtr,


### PR DESCRIPTION
- Shell app needs to call `WindowHelper.SetDarkModePreference` before context menus can become dark
- Also adds ability to disable rename option from appearing in item context menus