### PR TITLE
Allow jumbo icons outside ShellFolders

### DIFF
--- a/src/ManagedShell.Common/Helpers/IconHelper.cs
+++ b/src/ManagedShell.Common/Helpers/IconHelper.cs
@@ -156,6 +156,9 @@ namespace ManagedShell.Common.Helpers
                 case IconSize.ExtraLarge:
                     imlExtraLarge.GetIcon(iconIndex, ILD_TRANSPARENT, ref hIcon);
                     break;
+                case IconSize.Jumbo:
+                    imlJumbo.GetIcon(iconIndex, ILD_TRANSPARENT, ref hIcon);
+                    break;
             }
 
             return hIcon;


### PR DESCRIPTION
Originally thought these weren't supported, but it actually works.