### PR TITLE
Support to re-order windows inside their respective category

### DIFF
--- a/src/ManagedShell.WindowsTasks/ApplicationWindow.cs
+++ b/src/ManagedShell.WindowsTasks/ApplicationWindow.cs
@@ -108,6 +108,24 @@ namespace ManagedShell.WindowsTasks
             }
         }
 
+        private int _index;
+
+        public int Index
+        {
+            get
+            {
+                return _index;
+            }
+            set
+            {
+                if (value != _index)
+                {
+                    _index = value;
+                    OnPropertyChanged(nameof(Index));
+                }
+            }
+        }
+
         private string _category;
 
         public string Category

--- a/src/ManagedShell.WindowsTasks/Tasks.cs
+++ b/src/ManagedShell.WindowsTasks/Tasks.cs
@@ -1,65 +1,93 @@
 ﻿using System;
 using System.Collections.Specialized;
 using System.ComponentModel;
+using System.Linq;
 using System.Windows.Data;
 
 namespace ManagedShell.WindowsTasks
 {
-    public class Tasks : IDisposable
-    {
-        private readonly TasksService _tasksService;
-        private ICollectionView groupedWindows;
+	public class Tasks : IDisposable
+	{
+		private readonly TasksService _tasksService;
+		private ICollectionView groupedWindows;
 
-        public ICollectionView GroupedWindows => groupedWindows;
+		public ICollectionView GroupedWindows => groupedWindows;
 
-        public Tasks(TasksService tasksService)
-        {
-            _tasksService = tasksService;
-            // prepare collections
-            groupedWindows = CollectionViewSource.GetDefaultView(_tasksService.Windows);
-            groupedWindows.GroupDescriptions.Add(new PropertyGroupDescription("Category"));
-            groupedWindows.CollectionChanged += groupedWindows_Changed;
-            groupedWindows.Filter = groupedWindows_Filter;
+		public Tasks(TasksService tasksService)
+		{
+			_tasksService = tasksService;
+			// prepare collections
+			groupedWindows = CollectionViewSource.GetDefaultView(_tasksService.Windows);
+			groupedWindows.GroupDescriptions.Add(new PropertyGroupDescription(nameof(ApplicationWindow.Category)));
+			groupedWindows.SortDescriptions.Add(new SortDescription(nameof(ApplicationWindow.Index),
+				ListSortDirection.Ascending));
+			groupedWindows.CollectionChanged += groupedWindows_Changed;
+			groupedWindows.Filter = groupedWindows_Filter;
 
-            if (groupedWindows is ICollectionViewLiveShaping taskbarItemsView)
-            {
-                taskbarItemsView.IsLiveFiltering = true;
-                taskbarItemsView.LiveFilteringProperties.Add("ShowInTaskbar");
-                taskbarItemsView.IsLiveGrouping = true;
-                taskbarItemsView.LiveGroupingProperties.Add("Category");
-            }
-        }
+			if (groupedWindows is ICollectionViewLiveShaping taskbarItemsView)
+			{
+				taskbarItemsView.IsLiveFiltering = true;
+				taskbarItemsView.LiveFilteringProperties.Add(nameof(ApplicationWindow.ShowInTaskbar));
+				taskbarItemsView.IsLiveGrouping = true;
+				taskbarItemsView.LiveGroupingProperties.Add(nameof(ApplicationWindow.Category));
+				taskbarItemsView.IsLiveSorting = true;
+				taskbarItemsView.LiveSortingProperties.Add(nameof(ApplicationWindow.Index));
+			}
+		}
 
-        public void Initialize(ITaskCategoryProvider taskCategoryProvider)
-        {
-            if (!_tasksService.IsInitialized)
-            {
-                _tasksService.SetTaskCategoryProvider(taskCategoryProvider);
-                Initialize();
-            }
-        }
+		public void Initialize(ITaskCategoryProvider taskCategoryProvider)
+		{
+			if (!_tasksService.IsInitialized)
+			{
+				_tasksService.SetTaskCategoryProvider(taskCategoryProvider);
+				Initialize();
+			}
+		}
 
-        public void Initialize()
-        {
-            _tasksService.Initialize();
-        }
+		public void Move(IntPtr oldApplicationWindowHandle, IntPtr newApplicationWindowHandle)
+		{
+			var oldApplicationWindow =
+				_tasksService.Windows.FirstOrDefault(e => e.Handle == oldApplicationWindowHandle);
+			var newApplicationWindow =
+				_tasksService.Windows.FirstOrDefault(e => e.Handle == newApplicationWindowHandle);
+			if (oldApplicationWindow == null || newApplicationWindow == null)
+			{
+				return;
+			}
 
-        private void groupedWindows_Changed(object sender, NotifyCollectionChangedEventArgs e)
-        {
-            // yup, do nothing. helps prevent a NRE
-        }
+			if (oldApplicationWindow == newApplicationWindow)
+			{
+				return;
+			}
 
-        private bool groupedWindows_Filter(object item)
-        {
-            if (item is ApplicationWindow window && window.ShowInTaskbar)
-                return true;
+			if (oldApplicationWindow.Category != newApplicationWindow.Category)
+			{
+				return;
+			}
 
-            return false;
-        }
+			var tmp = oldApplicationWindow.Index;
+			oldApplicationWindow.Index = newApplicationWindow.Index;
+			newApplicationWindow.Index = tmp;
+		}
 
-        public void Dispose()
-        {
-            _tasksService.Dispose();
-        }
-    }
+		public void Initialize()
+		{
+			_tasksService.Initialize();
+		}
+
+		private void groupedWindows_Changed(object sender, NotifyCollectionChangedEventArgs e)
+		{
+			// yup, do nothing. helps prevent a NRE
+		}
+
+		private bool groupedWindows_Filter(object item)
+		{
+			return item is ApplicationWindow window && window.ShowInTaskbar;
+		}
+
+		public void Dispose()
+		{
+			_tasksService.Dispose();
+		}
+	}
 }


### PR DESCRIPTION
This change allows a consuming Shell to re-order the windows inside their categories, this is needed to implement re-ordering of windows in the taskbar of Cairo Shell.

Necessary for https://github.com/cairoshell/cairoshell/issues/536