### PR TITLE
Get task category only for visible tasks

### DIFF
--- a/src/ManagedShell.WindowsTasks/ApplicationWindow.cs
+++ b/src/ManagedShell.WindowsTasks/ApplicationWindow.cs
@@ -274,6 +274,13 @@ namespace ManagedShell.WindowsTasks
             if (_showInTaskbar != showInTaskbar)
             {
                 _showInTaskbar = showInTaskbar;
+
+                // If we are becoming visible in the taskbar, get the category if it hasn't been set yet
+                if (_showInTaskbar == true && Category == null)
+                {
+                    Category = _tasksService.TaskCategoryProvider?.GetCategory(this);
+                }
+
                 OnPropertyChanged("ShowInTaskbar");
             }
         }

--- a/src/ManagedShell.WindowsTasks/TasksService.cs
+++ b/src/ManagedShell.WindowsTasks/TasksService.cs
@@ -29,7 +29,7 @@ namespace ManagedShell.WindowsTasks
         private static IntPtr uncloakEventHook = IntPtr.Zero;
         private WinEventProc uncloakEventProc;
 
-        private ITaskCategoryProvider TaskCategoryProvider;
+        internal ITaskCategoryProvider TaskCategoryProvider;
         private TaskCategoryChangeDelegate CategoryChangeDelegate;
 
         public TasksService() : this(DEFAULT_ICON_SIZE)
@@ -119,9 +119,6 @@ namespace ManagedShell.WindowsTasks
             {
                 ApplicationWindow win = new ApplicationWindow(this, hwnd);
 
-                // set window category if provided by shell
-                win.Category = TaskCategoryProvider?.GetCategory(win);
-
                 if (win.CanAddToTaskbar && win.ShowInTaskbar && !Windows.Contains(win))
                     Windows.Add(win);
 
@@ -154,7 +151,10 @@ namespace ManagedShell.WindowsTasks
         {
             foreach (ApplicationWindow window in Windows)
             {
-                window.Category = TaskCategoryProvider?.GetCategory(window);
+                if (window.ShowInTaskbar)
+                {
+                    window.Category = TaskCategoryProvider?.GetCategory(window);
+                }
             }
         }
 
@@ -196,9 +196,6 @@ namespace ManagedShell.WindowsTasks
         private ApplicationWindow addWindow(IntPtr hWnd, ApplicationWindow.WindowState initialState = ApplicationWindow.WindowState.Inactive, bool sanityCheck = false)
         {
             ApplicationWindow win = new ApplicationWindow(this, hWnd);
-
-            // set window category if provided by shell
-            win.Category = TaskCategoryProvider?.GetCategory(win);
 
             // set window state if a non-default value is provided
             if (initialState != ApplicationWindow.WindowState.Inactive) win.State = initialState;


### PR DESCRIPTION
Dramatically reduces the number of times GetCategory is called. The consuming shell only has access to visible windows, so there's no reason to perform the work on non-visible windows (which is the vast majority).