### PR TITLE
Allow dark mode support in 21H1

### DIFF
--- a/src/ManagedShell.Common/Helpers/EnvironmentHelper.cs
+++ b/src/ManagedShell.Common/Helpers/EnvironmentHelper.cs
@@ -111,7 +111,7 @@ namespace ManagedShell.Common.Helpers
                 }
 
                 // This has an upper-bound due to the volatility of the undocumented dark mode API
-                return (osVersionMajor >= 10 && osVersionBuild >= 18362 && osVersionBuild <= 19042);
+                return (osVersionMajor >= 10 && osVersionBuild >= 18362 && osVersionBuild <= 19043);
             }
         }
 

--- a/src/ManagedShell.WindowsTasks/ApplicationWindow.cs
+++ b/src/ManagedShell.WindowsTasks/ApplicationWindow.cs
@@ -309,7 +309,7 @@ namespace ManagedShell.WindowsTasks
                 NativeMethods.GetClassName(Handle, cName, cName.Capacity);
                 if (cName.ToString() == "ApplicationFrameWindow" || cName.ToString() == "Windows.UI.Core.CoreWindow" || cName.ToString() == "Shell_CharmWindow" || cName.ToString() == "ImmersiveLauncher")
                 {
-                    if ((ExtendedWindowStyles & (int)NativeMethods.ExtendedWindowStyles.WS_EX_WINDOWEDGE) == 0 && string.IsNullOrEmpty(AppUserModelID))
+                    if ((ExtendedWindowStyles & (int)NativeMethods.ExtendedWindowStyles.WS_EX_WINDOWEDGE) == 0)
                     {
                         ShellLogger.Debug($"ApplicationWindow: Hiding UWP non-window {Title}");
                         return false;


### PR DESCRIPTION
Also fixes a UWP task visibility regression in newer Windows builds caused by a recent change.