### PR TITLE
Improve minimize/restore behavior

### DIFF
--- a/src/ManagedShell.WindowsTasks/ApplicationWindow.cs
+++ b/src/ManagedShell.WindowsTasks/ApplicationWindow.cs
@@ -463,25 +463,16 @@ namespace ManagedShell.WindowsTasks
         {
             if ((WindowStyles & (int)NativeMethods.WindowStyles.WS_MINIMIZEBOX) != 0)
             {
-                bool minimizeResult = NativeMethods.ShowWindow(Handle, NativeMethods.WindowShowStyle.Minimize);
-                if (!minimizeResult)
-                {
-                    // elevated windows require WM_SYSCOMMAND messages
-                    IntPtr retval = IntPtr.Zero;
-                    NativeMethods.SendMessageTimeout(Handle, (int)NativeMethods.WM.SYSCOMMAND, NativeMethods.SC_MINIMIZE, 0, 2, 200, ref retval);
-                }
+                IntPtr retval = IntPtr.Zero;
+                NativeMethods.SendMessageTimeout(Handle, (int)NativeMethods.WM.SYSCOMMAND, NativeMethods.SC_MINIMIZE, 0, 2, 200, ref retval);
             }
         }
 
         public void Restore()
         {
-            bool restoreResult = NativeMethods.ShowWindow(Handle, NativeMethods.WindowShowStyle.Restore);
-            if (!restoreResult)
-            {
-                // elevated windows require WM_SYSCOMMAND messages
-                IntPtr retval = IntPtr.Zero;
-                NativeMethods.SendMessageTimeout(Handle, (int)NativeMethods.WM.SYSCOMMAND, NativeMethods.SC_RESTORE, 0, 2, 200, ref retval);
-            }
+            IntPtr retval = IntPtr.Zero;
+            NativeMethods.SendMessageTimeout(Handle, (int)NativeMethods.WM.SYSCOMMAND, NativeMethods.SC_RESTORE, 0, 2, 200, ref retval);
+
             NativeMethods.SetForegroundWindow(Handle);
         }
 

--- a/src/ManagedShell.WindowsTasks/TasksService.cs
+++ b/src/ManagedShell.WindowsTasks/TasksService.cs
@@ -299,7 +299,7 @@ namespace ManagedShell.WindowsTasks
                                     {
                                         foreach (ApplicationWindow wind in Windows)
                                         {
-                                            if (wind.WinFileName == win.WinFileName)
+                                            if (wind.WinFileName == win.WinFileName && wind.Handle != win.Handle)
                                                 wind.SetShowInTaskbar();
                                         }
                                     }
@@ -345,7 +345,7 @@ namespace ManagedShell.WindowsTasks
 
                                     foreach (ApplicationWindow wind in Windows)
                                     {
-                                        if (wind.WinFileName == win.WinFileName)
+                                        if (wind.WinFileName == win.WinFileName && wind.Handle != win.Handle)
                                         {
                                             wind.UpdateProperties();
                                         }


### PR DESCRIPTION
Always use SC_RESTORE or SC_MINIMIZE as that is what Explorer does. This takes care of cairoshell/cairoshell#564.

Also added minor optimization to TasksService.