### PR TITLE
Support GPO for hiding system notification area icons

### DIFF
--- a/src/ManagedShell.Common/Helpers/GroupPolicyHelper.cs
+++ b/src/ManagedShell.Common/Helpers/GroupPolicyHelper.cs
@@ -31,6 +31,78 @@ namespace ManagedShell.Common.Helpers
         public static bool NoDesktop => Registry.CurrentUser.GetSubKeyValue<int>(ExplorerPolicyKey, "NoDesktop") == 1;
 
         /// <summary>
+        /// This policy setting allows you to remove Security and Maintenance from the system control area.
+        ///
+        /// If you enable this policy setting, the Security and Maintenance icon is not displayed in the system notification area.
+        ///
+        /// If you disable or do not configure this policy setting, the Security and Maintenance icon is displayed in the system notification area. 
+        /// </summary>
+        /// <remarks>
+        /// Policy: Remove the Security and Maintenance icon
+        /// Category Path: User Configuration\Administrative Templates\Start Menu and Taskbar\
+        /// Supported On: At least Microsoft Windows Vista
+        /// Registry Key: HKCU\Software\Microsoft\Windows\CurrentVersion\Policies\Explorer
+        /// Value: HideSCAHealth
+        /// Admx: Taskbar.admx
+        /// Documentation: https://gpsearch.azurewebsites.net/#4678
+        /// </remarks>
+        public static bool HideScaHealth => Registry.CurrentUser.GetSubKeyValue<int>(ExplorerPolicyKey, "HideSCAHealth") == 1;
+
+        /// <summary>
+        /// This policy setting allows you to remove the Meet Now icon from the system control area.
+        ///
+        /// If you enable this policy setting, the Meet Now icon is not displayed in the system notification area.
+        /// 
+        /// If you disable or do not configure this policy setting, the Meet Now icon is displayed in the system notification area. 
+        /// </summary>
+        /// <remarks>
+        /// Policy: Remove the volume control icon
+        /// Category Path: User Configuration\Administrative Templates\Start Menu and Taskbar\
+        /// Supported On: At least Microsoft Windows Vista
+        /// Registry Key: HKCU\Software\Microsoft\Windows\CurrentVersion\Policies\Explorer
+        /// Value: HideSCAMeetNow
+        /// Admx: Taskbar.admx
+        /// Documentation: https://gpsearch.azurewebsites.net/#15675
+        /// </remarks>
+        public static bool HideScaMeetNow => Registry.CurrentUser.GetSubKeyValue<int>(ExplorerPolicyKey, "HideSCAMeetNow") == 1;
+
+        /// <summary>
+        /// This policy setting allows you to remove the networking icon from the system control area.
+        ///
+        /// If you enable this policy setting, the networking icon is not displayed in the system notification area.
+        ///
+        /// If you disable or do not configure this policy setting, the networking icon is displayed in the system notification area. 
+        /// </summary>
+        /// <remarks>
+        /// Policy: Remove the networking icon
+        /// Category Path: User Configuration\Administrative Templates\Start Menu and Taskbar\
+        /// Supported On: At least Microsoft Windows Vista
+        /// Registry Key: HKCU\Software\Microsoft\Windows\CurrentVersion\Policies\Explorer
+        /// Value: HideSCANetwork
+        /// Admx: Taskbar.admx
+        /// Documentation: https://gpsearch.azurewebsites.net/#4676
+        /// </remarks>
+        public static bool HideScaNetwork => Registry.CurrentUser.GetSubKeyValue<int>(ExplorerPolicyKey, "HideSCANetwork") == 1;
+
+        /// <summary>
+        /// This policy setting allows you to remove the battery meter from the system control area.
+        ///
+        /// If you enable this policy setting, the battery meter is not displayed in the system notification area.
+        ///
+        /// If you disable or do not configure this policy setting, the battery meter is displayed in the system notification area. 
+        /// </summary>
+        /// <remarks>
+        /// Policy: Remove the battery meter
+        /// Category Path: User Configuration\Administrative Templates\Start Menu and Taskbar\
+        /// Supported On: At least Microsoft Windows Vista
+        /// Registry Key: HKCU\Software\Microsoft\Windows\CurrentVersion\Policies\Explorer
+        /// Value: HideSCAPower
+        /// Admx: Taskbar.admx
+        /// Documentation: https://gpsearch.azurewebsites.net/#4675
+        /// </remarks>
+        public static bool HideScaPower => Registry.CurrentUser.GetSubKeyValue<int>(ExplorerPolicyKey, "HideSCAPower") == 1;
+
+        /// <summary>
         /// This policy setting allows you to remove the volume control icon from the system control area.
         /// 
         /// If you enable this policy setting, the volume control icon is not displayed in the system notification area.

--- a/src/ManagedShell.WindowsTray/NotificationArea.cs
+++ b/src/ManagedShell.WindowsTray/NotificationArea.cs
@@ -13,14 +13,19 @@ namespace ManagedShell.WindowsTray
 {
     public class NotificationArea : DependencyObject, IDisposable
     {
+        const string HEALTH_GUID = "7820ae76-23e3-4229-82c1-e41cb67d5b9c";
+        const string MEETNOW_GUID = "7820ae83-23e3-4229-82c1-e41cb67d5b9c";
+        const string NETWORK_GUID = "7820ae74-23e3-4229-82c1-e41cb67d5b9c";
+        const string POWER_GUID = "7820ae75-23e3-4229-82c1-e41cb67d5b9c";
+        const string VOLUME_GUID = "7820ae73-23e3-4229-82c1-e41cb67d5b9c";
+
         public static readonly string[] DEFAULT_PINNED = {
-            "7820ae76-23e3-4229-82c1-e41cb67d5b9c",
-            "7820ae75-23e3-4229-82c1-e41cb67d5b9c",
-            "7820ae74-23e3-4229-82c1-e41cb67d5b9c",
-            "7820ae73-23e3-4229-82c1-e41cb67d5b9c"
+            HEALTH_GUID,
+            POWER_GUID,
+            NETWORK_GUID,
+            VOLUME_GUID
         };
 
-        const string VOLUME_GUID = "7820ae73-23e3-4229-82c1-e41cb67d5b9c";
         readonly NativeMethods.Rect defaultPlacement = new NativeMethods.Rect
         {
             Top = 0,
@@ -255,6 +260,13 @@ namespace ManagedShell.WindowsTray
 
                         // hide icons while we are shell which require UWP support & we have a separate implementation for
                         if (nicData.guidItem == new Guid(VOLUME_GUID) && ((EnvironmentHelper.IsAppRunningAsShell && EnvironmentHelper.IsWindows10OrBetter) || GroupPolicyHelper.HideScaVolume))
+                            return false;
+
+                        // hide icons per group policy
+                        if ((nicData.guidItem == new Guid(HEALTH_GUID) && GroupPolicyHelper.HideScaHealth) ||
+                            (nicData.guidItem == new Guid(MEETNOW_GUID) && GroupPolicyHelper.HideScaMeetNow) ||
+                            (nicData.guidItem == new Guid(NETWORK_GUID) && GroupPolicyHelper.HideScaNetwork) ||
+                            (nicData.guidItem == new Guid(POWER_GUID) && GroupPolicyHelper.HideScaPower))
                             return false;
 
                         foreach (NotifyIcon ti in TrayIcons)


### PR DESCRIPTION
Adds GPO support to hide the following icons:

- Action Center (Windows 7/8)
- Battery
- Meet Now (Windows 10)
- Network

Volume was already supported.

Reference: cairoshell/cairoshell#588