### PR TITLE
Properly fix UI freezing when comparing files

### DIFF
--- a/src/ManagedShell.WindowsTasks/ITaskCategoryProvider.cs
+++ b/src/ManagedShell.WindowsTasks/ITaskCategoryProvider.cs
@@ -1,11 +1,12 @@
 ﻿using System;
+using System.Threading.Tasks;
 
 namespace ManagedShell.WindowsTasks
 {
     public interface ITaskCategoryProvider : IDisposable
     {
-        string GetCategory(ApplicationWindow window);
+        Task<string> GetCategoryAsync(ApplicationWindow window);
 
-        void SetCategoryChangeDelegate(TaskCategoryChangeDelegate changeDelegate);
+        void SetCategoryChangeDelegate(TaskCategoryChangeAsyncDelegate changeAsyncDelegate);
     }
 }

--- a/src/ManagedShell.WindowsTasks/TaskCategoryChangeAsyncDelegate.cs
+++ b/src/ManagedShell.WindowsTasks/TaskCategoryChangeAsyncDelegate.cs
@@ -1,0 +1,6 @@
+﻿using System.Threading.Tasks;
+
+namespace ManagedShell.WindowsTasks
+{
+    public delegate Task TaskCategoryChangeAsyncDelegate();
+}

--- a/src/ManagedShell.WindowsTasks/TaskCategoryChangeDelegate.cs
+++ b/src/ManagedShell.WindowsTasks/TaskCategoryChangeDelegate.cs
@@ -1,4 +1,0 @@
-﻿namespace ManagedShell.WindowsTasks
-{
-    public delegate void TaskCategoryChangeDelegate();
-}


### PR DESCRIPTION
I have seen that the call to file comparison when evaluating category was changed to a Task.Run. Currently it is implemented as fire and forget which seems unwise.

I have changed the CategoryProvider interface and the implementation in Cairo Desktop (see https://github.com/kevinboss/cairoshell/tree/categoryprovider-async) to use Async/Await which allows us to not fire and forget the category detection by file comparison but still reap the benefit of a responsive UI.