### PR TITLE
Forward more AppBar messages

### DIFF
--- a/src/ManagedShell.AppBar/AppBarManager.cs
+++ b/src/ManagedShell.AppBar/AppBarManager.cs
@@ -52,10 +52,8 @@ namespace ManagedShell.AppBar
                     {
                         uCallBack = RegisterWindowMessage("AppBarMessage");
                         abd.uCallbackMessage = uCallBack;
-
-                        _explorerHelper.SuspendTrayService();
+                        
                         SHAppBarMessage((int) ABMsg.ABM_NEW, ref abd);
-                        _explorerHelper.ResumeTrayService();
                     }
                     
                     AppBars.Add(abWindow);
@@ -75,9 +73,7 @@ namespace ManagedShell.AppBar
                 {
                     if (!EnvironmentHelper.IsAppRunningAsShell)
                     {
-                        _explorerHelper.SuspendTrayService();
                         SHAppBarMessage((int) ABMsg.ABM_REMOVE, ref abd);
-                        _explorerHelper.ResumeTrayService();
                     }
 
                     AppBars.Remove(abWindow);
@@ -103,10 +99,8 @@ namespace ManagedShell.AppBar
                 hWnd = hwnd,
                 lParam = (IntPtr)Convert.ToInt32(true)
             };
-
-            _explorerHelper.SuspendTrayService();
+            
             SHAppBarMessage((int)ABMsg.ABM_ACTIVATE, ref abd);
-            _explorerHelper.ResumeTrayService();
 
             // apparently the TaskBars like to pop up when AppBars change
             if (_explorerHelper.HideExplorerTaskbar)
@@ -122,10 +116,8 @@ namespace ManagedShell.AppBar
                 cbSize = Marshal.SizeOf(typeof(APPBARDATA)),
                 hWnd = hwnd
             };
-
-            _explorerHelper.SuspendTrayService();
+            
             SHAppBarMessage((int)ABMsg.ABM_WINDOWPOSCHANGED, ref abd);
-            _explorerHelper.ResumeTrayService();
 
             // apparently the TaskBars like to pop up when AppBars change
             if (_explorerHelper.HideExplorerTaskbar)

--- a/src/ManagedShell.AppBar/ExplorerHelper.cs
+++ b/src/ManagedShell.AppBar/ExplorerHelper.cs
@@ -48,7 +48,7 @@ namespace ManagedShell.AppBar
 
         public void SuspendTrayService()
         {
-            // get shell window back so we can do appbar stuff
+            // get Explorer tray window back so we can do appbar stuff that requires shared memory
             _notificationArea?.Suspend();
         }
 
@@ -107,10 +107,8 @@ namespace ManagedShell.AppBar
                     hWnd = FindTaskbarHwnd(),
                     lParam = (IntPtr) state
                 };
-
-                SuspendTrayService();
+                
                 SHAppBarMessage((int) ABMsg.ABM_SETSTATE, ref abd);
-                ResumeTrayService();
             });
         }
 
@@ -121,10 +119,8 @@ namespace ManagedShell.AppBar
                 cbSize = Marshal.SizeOf(typeof(APPBARDATA)),
                 hWnd = FindTaskbarHwnd()
             };
-
-            SuspendTrayService();
+            
             uint uState = SHAppBarMessage((int)ABMsg.ABM_GETSTATE, ref abd);
-            ResumeTrayService();
 
             return (TaskbarState)uState;
         }

--- a/src/ManagedShell.WindowsTray/TrayService.cs
+++ b/src/ManagedShell.WindowsTray/TrayService.cs
@@ -160,10 +160,14 @@ namespace ManagedShell.WindowsTray
                                     break;
                                 }
 
-                                if (AppBarMessageAction(amd))
+                                IntPtr abmResult = AppBarMessageAction(amd);
+
+                                if (abmResult != IntPtr.Zero)
                                 {
-                                    return (IntPtr)1;
+                                    return abmResult;
                                 }
+
+                                ShellLogger.Debug($"TrayService: Forwarding AppBar message {(ABMsg)amd.dwMessage} from PID {amd.dwSourceProcessId}");
                             }
                             else
                             {
@@ -227,7 +231,7 @@ namespace ManagedShell.WindowsTray
         }
 
         #region Event handling
-        private bool AppBarMessageAction(APPBARMSGDATAV3 amd)
+        private IntPtr AppBarMessageAction(APPBARMSGDATAV3 amd)
         {
             // only handle ABM_GETTASKBARPOS, send other AppBar messages to default handler
             switch ((ABMsg)amd.dwMessage)
@@ -239,9 +243,9 @@ namespace ManagedShell.WindowsTray
                     Marshal.StructureToPtr(abd, hShared, false);
                     SHUnlockShared(hShared);
                     ShellLogger.Debug("TrayService: Responded to ABM_GETTASKBARPOS");
-                    return true;
+                    return (IntPtr)1;
             }
-            return false;
+            return IntPtr.Zero;
         }
 
         private void FillTrayHostSizeData(ref APPBARDATAV2 abd)


### PR DESCRIPTION
As opposed to the current strategy of always suspending our tray for each AppBar message. It seems forwarding works fine from our tray to Explorer for all AppBar messages sent by our own windows, except ABM_[GET/SET]POS, which use shared memory.

This results in better tray reliability as fewer messages are missed.