### PR TITLE
More reliably keep notification area running & taskbar hidden

### DIFF
--- a/src/ManagedShell.AppBar/AppBarWindow.cs
+++ b/src/ManagedShell.AppBar/AppBarWindow.cs
@@ -156,10 +156,6 @@ namespace ManagedShell.AppBar
                         }
 
                         break;
-
-                    case NativeMethods.AppBarNotifications.FullScreenApp:
-                        _explorerHelper.HideTaskbar();
-                        break;
                 }
                 handled = true;
             }
@@ -311,12 +307,6 @@ namespace ManagedShell.AppBar
         #region Virtual methods
         public virtual void AfterAppBarPos(bool isSameCoords, NativeMethods.Rect rect)
         {
-            // apparently the TaskBars like to pop up when AppBars change
-            if (_explorerHelper.HideExplorerTaskbar && !AllowClose)
-            {
-                _explorerHelper.HideTaskbar();
-            }
-
             if (!isSameCoords)
             {
                 var timer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(0.1) };

--- a/src/ManagedShell.Common/Helpers/WindowHelper.cs
+++ b/src/ManagedShell.Common/Helpers/WindowHelper.cs
@@ -6,6 +6,8 @@ namespace ManagedShell.Common.Helpers
 {
     public static class WindowHelper
     {
+        public const string TrayWndClass = "Shell_TrayWnd";
+
         public static void ShowWindowBottomMost(IntPtr handle)
         {
             SetWindowPos(
@@ -176,6 +178,21 @@ namespace ManagedShell.Common.Helpers
             }
 
             return false;
+        }
+
+        public static IntPtr FindWindowsTray(IntPtr hwndIgnore)
+        {
+            IntPtr taskbarHwnd = FindWindow(TrayWndClass, "");
+
+            if (hwndIgnore != IntPtr.Zero)
+            {
+                while (taskbarHwnd == hwndIgnore)
+                {
+                    taskbarHwnd = FindWindowEx(IntPtr.Zero, taskbarHwnd, TrayWndClass, "");
+                }
+            }
+
+            return taskbarHwnd;
         }
     }
 }


### PR DESCRIPTION
1. Merges `ExplorerHelper.FindTaskbarHwnd` and `TrayService.FindWindowsTray` to `WindowHelper.FindWindowsTray`
2. Creates a monitor that will bring our Shell_TrayWnd to the top if the Explorer Shell_TrayWnd becomes topmost. This is more important now that the suspend/resume, which forced us back to the top, is used significantly less after #26.
3. Creates a monitor that will hide the Explorer taskbar if it is shown while `HideExplorerTaskbar == true`. This fixes the Explorer taskbar showing up in circumstances that we cannot predict. Removed usages and ability to force-hide it elsewhere since that is no longer needed.