### PR TITLE
IAppVisibility

### DIFF
--- a/src/ManagedShell.Common/Enums/MONITOR_APP_VISIBILITY.cs
+++ b/src/ManagedShell.Common/Enums/MONITOR_APP_VISIBILITY.cs
@@ -1,0 +1,9 @@
+﻿namespace ManagedShell.Common.Enums
+{
+    public enum MONITOR_APP_VISIBILITY
+    {
+        MAV_UNKNOWN = 0,
+        MAV_NO_APP_VISIBLE = 1,
+        MAV_APP_VISIBLE = 2
+    }
+}

--- a/src/ManagedShell.Common/Helpers/AppVisibilityHelper.cs
+++ b/src/ManagedShell.Common/Helpers/AppVisibilityHelper.cs
@@ -15,6 +15,7 @@ namespace ManagedShell.Common.Helpers
         private int _eventCookie;
         private bool _useEvents;
 
+        // Note: when using events, this object must be held in memory by the consumer
         public AppVisibilityHelper(bool useEvents)
         {
             if (!EnvironmentHelper.IsWindows8OrBetter)

--- a/src/ManagedShell.Common/Helpers/AppVisibilityHelper.cs
+++ b/src/ManagedShell.Common/Helpers/AppVisibilityHelper.cs
@@ -56,6 +56,10 @@ namespace ManagedShell.Common.Helpers
                 // subscribed to events successfully
                 ShellLogger.Debug("AppVisibilityHelper: Subscribed to change events");
             }
+            else
+            {
+                ShellLogger.Debug("AppVisibilityHelper: Unable to subscribe to change events");
+            }
         }
 
         private void Events_AppVisibilityChanged(object sender, AppVisibilityEventArgs e)

--- a/src/ManagedShell.Common/Helpers/AppVisibilityHelper.cs
+++ b/src/ManagedShell.Common/Helpers/AppVisibilityHelper.cs
@@ -1,0 +1,109 @@
+﻿using System;
+using ManagedShell.Common.Enums;
+using ManagedShell.Common.Interfaces;
+using ManagedShell.Common.Logging;
+using ManagedShell.Common.SupportingClasses;
+
+namespace ManagedShell.Common.Helpers
+{
+    public class AppVisibilityHelper : IDisposable
+    {
+        public event EventHandler<AppVisibilityEventArgs> AppVisibilityChanged;
+        public event EventHandler<LauncherVisibilityEventArgs> LauncherVisibilityChanged;
+
+        private IAppVisibility appVis;
+        private int eventCookie;
+
+        public AppVisibilityHelper()
+        {
+            if (!EnvironmentHelper.IsWindows8OrBetter)
+            {
+                return;
+            }
+
+            // register for app visibility events
+            appVis = (IAppVisibility)new AppVisibility();
+
+            if (appVis == null)
+            {
+                return;
+            }
+
+            AppVisibilityEvents events = new AppVisibilityEvents();
+            events.AppVisibilityChanged += Events_AppVisibilityChanged;
+            events.LauncherVisibilityChanged += Events_LauncherVisibilityChanged;
+
+            if (appVis.Advise(events, out eventCookie) == 0)
+            {
+                // subscribed to events successfully
+                ShellLogger.Debug("AppVisibilityHelper: Subscribed to change events");
+            }
+        }
+
+        private void Events_AppVisibilityChanged(object sender, AppVisibilityEventArgs e)
+        {
+            AppVisibilityChanged?.Invoke(sender, e);
+        }
+
+        private void Events_LauncherVisibilityChanged(object sender, LauncherVisibilityEventArgs e)
+        {
+            LauncherVisibilityChanged?.Invoke(sender, e);
+        }
+
+        public bool IsLauncherVisible()
+        {
+            if (!EnvironmentHelper.IsWindows8OrBetter)
+            {
+                return false;
+            }
+
+            if (appVis == null)
+            {
+                return false;
+            }
+
+            appVis.IsLauncherVisible(out bool pfVisible);
+
+            return pfVisible;
+        }
+
+        public MONITOR_APP_VISIBILITY GetAppVisibilityOnMonitor(IntPtr hMonitor)
+        {
+            if (!EnvironmentHelper.IsWindows8OrBetter)
+            {
+                return MONITOR_APP_VISIBILITY.MAV_UNKNOWN;
+            }
+
+            if (appVis == null)
+            {
+                return MONITOR_APP_VISIBILITY.MAV_UNKNOWN;
+            }
+
+            appVis.GetAppVisibilityOnMonitor(hMonitor, out MONITOR_APP_VISIBILITY pMode);
+
+            return pMode;
+        }
+
+        public void Dispose()
+        {
+            if (!EnvironmentHelper.IsWindows8OrBetter)
+            {
+                return;
+            }
+
+            if (appVis == null)
+            {
+                return;
+            }
+
+            if (eventCookie > 0)
+            {
+                // unregister from events
+                if (appVis.Unadvise(eventCookie) == 0)
+                {
+                    ShellLogger.Debug("AppVisibilityHelper: Unsubscribed from change events");
+                }
+            }
+        }
+    }
+}

--- a/src/ManagedShell.Common/Interfaces/IAppVisibility.cs
+++ b/src/ManagedShell.Common/Interfaces/IAppVisibility.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using ManagedShell.Common.Enums;
+
+namespace ManagedShell.Common.Interfaces
+{
+    [ComImport, Guid("2246EA2D-CAEA-4444-A3C4-6DE827E44313"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public interface IAppVisibility
+    {
+        long GetAppVisibilityOnMonitor([In] IntPtr hMonitor, [Out] out MONITOR_APP_VISIBILITY pMode);
+        long IsLauncherVisible([Out] out bool pfVisible);
+        long Advise([In] IAppVisibilityEvents pCallback, [Out] out int pdwCookie);
+        long Unadvise([In] int dwCookie);
+    }
+}

--- a/src/ManagedShell.Common/Interfaces/IAppVisibilityEvents.cs
+++ b/src/ManagedShell.Common/Interfaces/IAppVisibilityEvents.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using ManagedShell.Common.Enums;
+
+namespace ManagedShell.Common.Interfaces
+{
+    [ComImport, Guid("6584CE6B-7D82-49C2-89C9-C6BC02BA8C38"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public interface IAppVisibilityEvents
+    {
+        long AppVisibilityOnMonitorChanged(
+            [In] IntPtr hMonitor,
+            [In] MONITOR_APP_VISIBILITY previousMode,
+            [In] MONITOR_APP_VISIBILITY currentMode);
+
+        long LauncherVisibilityChange([In] bool currentVisibleState);
+    }
+}

--- a/src/ManagedShell.Common/SupportingClasses/AppVisibility.cs
+++ b/src/ManagedShell.Common/SupportingClasses/AppVisibility.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace ManagedShell.Common.SupportingClasses
+{
+    [ComImport, Guid("7E5FE3D9-985F-4908-91F9-EE19F9FD1514")]
+    class AppVisibility
+    {
+    }
+}

--- a/src/ManagedShell.Common/SupportingClasses/AppVisibilityEventArgs.cs
+++ b/src/ManagedShell.Common/SupportingClasses/AppVisibilityEventArgs.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using ManagedShell.Common.Enums;
+
+namespace ManagedShell.Common.SupportingClasses
+{
+    public class AppVisibilityEventArgs : EventArgs
+    {
+        public IntPtr MonitorHandle;
+        public MONITOR_APP_VISIBILITY PreviousMode;
+        public MONITOR_APP_VISIBILITY CurrentMode;
+    }
+}

--- a/src/ManagedShell.Common/SupportingClasses/AppVisibilityEvents.cs
+++ b/src/ManagedShell.Common/SupportingClasses/AppVisibilityEvents.cs
@@ -1,0 +1,40 @@
+﻿using ManagedShell.Common.Logging;
+using System;
+using System.Runtime.InteropServices;
+using ManagedShell.Common.Enums;
+using ManagedShell.Common.Interfaces;
+
+namespace ManagedShell.Common.SupportingClasses
+{
+    class AppVisibilityEvents : IAppVisibilityEvents
+    {
+        internal event EventHandler<AppVisibilityEventArgs> AppVisibilityChanged;
+        internal event EventHandler<LauncherVisibilityEventArgs> LauncherVisibilityChanged;
+
+        public AppVisibilityEvents() { }
+
+        public long AppVisibilityOnMonitorChanged([In] IntPtr hMonitor, [In] MONITOR_APP_VISIBILITY previousMode, [In] MONITOR_APP_VISIBILITY currentMode)
+        {
+            AppVisibilityEventArgs args = new AppVisibilityEventArgs
+            {
+                MonitorHandle = hMonitor,
+                PreviousMode = previousMode,
+                CurrentMode = currentMode
+            };
+
+            AppVisibilityChanged?.Invoke(this, args);
+            return 0;
+        }
+
+        public long LauncherVisibilityChange([In] bool currentVisibleState)
+        {
+            LauncherVisibilityEventArgs args = new LauncherVisibilityEventArgs
+            {
+                Visible = currentVisibleState
+            };
+
+            LauncherVisibilityChanged?.Invoke(this, args);
+            return 0;
+        }
+    }
+}

--- a/src/ManagedShell.Common/SupportingClasses/AppVisibilityEvents.cs
+++ b/src/ManagedShell.Common/SupportingClasses/AppVisibilityEvents.cs
@@ -1,5 +1,4 @@
-﻿using ManagedShell.Common.Logging;
-using System;
+﻿using System;
 using System.Runtime.InteropServices;
 using ManagedShell.Common.Enums;
 using ManagedShell.Common.Interfaces;

--- a/src/ManagedShell.Common/SupportingClasses/LauncherVisibilityEventArgs.cs
+++ b/src/ManagedShell.Common/SupportingClasses/LauncherVisibilityEventArgs.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace ManagedShell.Common.SupportingClasses
+{
+    public class LauncherVisibilityEventArgs : EventArgs
+    {
+        public bool Visible;
+    }
+}

--- a/src/ManagedShell.WindowsTray/TrayService.cs
+++ b/src/ManagedShell.WindowsTray/TrayService.cs
@@ -227,7 +227,7 @@ namespace ManagedShell.WindowsTray
                 msg == (int)WM.COMMAND ||
                 msg >= (int)WM.USER)
             {
-                return ForwardMsg(msg, wParam, lParam);
+                return ForwardMsg(hWnd, msg, wParam, lParam);
             }
 
             return DefWindowProc(hWnd, msg, wParam, lParam);
@@ -265,7 +265,7 @@ namespace ManagedShell.WindowsTray
             }
         }
 
-        private IntPtr ForwardMsg(int msg, IntPtr wParam, IntPtr lParam)
+        private IntPtr ForwardMsg(IntPtr hWnd, int msg, IntPtr wParam, IntPtr lParam)
         {
             if (HwndFwd == IntPtr.Zero || !IsWindow(HwndFwd))
             {
@@ -277,7 +277,7 @@ namespace ManagedShell.WindowsTray
                 return SendMessage(HwndFwd, msg, wParam, lParam);
             }
 
-            return IntPtr.Zero;
+            return DefWindowProc(hWnd, msg, wParam, lParam);
         }
         #endregion
 


### PR DESCRIPTION
Adds IAppVisibility functionality via AppVisibilityHelper. Query functionality works on Windows 8 or later, subscribing to events requires Windows 10 or later because of an access violation in system DLLs on Windows 8.

The primary use case of IAppVisibility is to know when the start menu is open.