### PR TITLE
Set tray window position from TrayHostSizeData

### DIFF
--- a/src/ManagedShell.WindowsTray/NotificationArea.cs
+++ b/src/ManagedShell.WindowsTray/NotificationArea.cs
@@ -401,10 +401,11 @@ namespace ManagedShell.WindowsTray
         }
         #endregion
 
-        // The notification area control calls this when an icon is clicked to set the placement of its host for ABM_GETTASKBARPOS usage
+        // The notification area control calls this when an icon is clicked to set the placement of its host (such as for ABM_GETTASKBARPOS usage)
         public void SetTrayHostSizeData(TrayHostSizeData data)
         {
             trayHostSizeData = data;
+            _trayService?.SetTrayHostSizeData(trayHostSizeData);
         }
 
         public void Dispose()

--- a/src/ManagedShell.WindowsTray/TrayService.cs
+++ b/src/ManagedShell.WindowsTray/TrayService.cs
@@ -48,6 +48,11 @@ namespace ManagedShell.WindowsTray
 
         internal IntPtr Initialize()
         {
+            if (HwndTray != IntPtr.Zero)
+            {
+                return HwndTray;
+            }
+
             DestroyWindows();
 
             wndProcDelegate = WndProc;
@@ -95,8 +100,15 @@ namespace ManagedShell.WindowsTray
 
         internal void SetTrayHostSizeData(TrayHostSizeData data)
         {
-            SetWindowPos(HwndTray, IntPtr.Zero, data.rc.Left, data.rc.Top, data.rc.Width, data.rc.Height, (int)SetWindowPosFlags.SWP_NOACTIVATE | (int)SetWindowPosFlags.SWP_NOZORDER);
-            SetWindowPos(HwndNotify, IntPtr.Zero, data.rc.Left, data.rc.Top, data.rc.Width, data.rc.Height, (int)SetWindowPosFlags.SWP_NOACTIVATE | (int)SetWindowPosFlags.SWP_NOZORDER);
+            if (HwndTray != IntPtr.Zero)
+            {
+                SetWindowPos(HwndTray, IntPtr.Zero, data.rc.Left, data.rc.Top, data.rc.Width, data.rc.Height, (int)SetWindowPosFlags.SWP_NOACTIVATE | (int)SetWindowPosFlags.SWP_NOZORDER);
+            }
+
+            if (HwndNotify != IntPtr.Zero)
+            {
+                SetWindowPos(HwndNotify, IntPtr.Zero, data.rc.Left, data.rc.Top, data.rc.Width, data.rc.Height, (int)SetWindowPosFlags.SWP_NOACTIVATE | (int)SetWindowPosFlags.SWP_NOZORDER);
+            }
         }
 
         private void SendTaskbarCreated()

--- a/src/ManagedShell.WindowsTray/TrayService.cs
+++ b/src/ManagedShell.WindowsTray/TrayService.cs
@@ -93,6 +93,12 @@ namespace ManagedShell.WindowsTray
             }
         }
 
+        internal void SetTrayHostSizeData(TrayHostSizeData data)
+        {
+            SetWindowPos(HwndTray, IntPtr.Zero, data.rc.Left, data.rc.Top, data.rc.Width, data.rc.Height, (int)SetWindowPosFlags.SWP_NOACTIVATE | (int)SetWindowPosFlags.SWP_NOZORDER);
+            SetWindowPos(HwndNotify, IntPtr.Zero, data.rc.Left, data.rc.Top, data.rc.Width, data.rc.Height, (int)SetWindowPosFlags.SWP_NOACTIVATE | (int)SetWindowPosFlags.SWP_NOZORDER);
+        }
+
         private void SendTaskbarCreated()
         {
             int msg = RegisterWindowMessage("TaskbarCreated");


### PR DESCRIPTION
This fixes Volume2 positioning (dremin/RetroBar#81). ManagedShell originally positioned the Shell_TrayWnd at the same place as the Cairo menu bar due to legacy. Now, it moves to the position specified by the shell.