### PR TITLE
Notification balloon support

### DIFF
--- a/src/ManagedShell.Interop/NativeMethods.Shell32.cs
+++ b/src/ManagedShell.Interop/NativeMethods.Shell32.cs
@@ -239,9 +239,16 @@ namespace ManagedShell.Interop
         [DllImport(Shell32_DllName, CharSet = CharSet.Auto)]
         public static extern int SHFileOperation(ref SHFILEOPSTRUCT FileOp);
 
-        public const uint NIN_SELECT = 0x400;
-        public const uint NIN_POPUPOPEN = 0x406;
-        public const uint NIN_POPUPCLOSE = 0x407;
+        public enum NIN : uint
+        {
+            SELECT = 0x400,
+            BALLOONSHOW = 0x402,
+            BALLOONHIDE = 0x403,
+            BALLOONTIMEOUT = 0x404,
+            BALLOONUSERCLICK = 0x405,
+            POPUPOPEN = 0x406,
+            POPUPCLOSE = 0x407,
+        }
 
         /// <summary>
         /// Numerical values of the NIM_* messages represented as an enumeration.

--- a/src/ManagedShell.Interop/NativeMethods.Shell32.cs
+++ b/src/ManagedShell.Interop/NativeMethods.Shell32.cs
@@ -301,6 +301,28 @@ namespace ManagedShell.Interop
         }
 
         /// <summary>
+        /// Notify icon info balloon flags
+        /// </summary>
+        [Flags]
+        public enum NIIF : uint
+        {
+            NONE = 0x00000000,
+            INFO = 0x00000001,
+            WARNING = 0x00000002,
+            ERROR = 0x00000003,
+            /// <summary>Use app-provided icon in the balloon. XP SP2 and later.</summary>
+            USER = 0x00000004,
+            /// <summary>XP and later.</summary>
+            NOSOUND = 0x00000010,
+            /// <summary>Vista and later.</summary>
+            LARGE_ICON = 0x00000020,
+            /// <summary>Windows 7 and later</summary>
+            NIIF_RESPECT_QUIET_TIME = 0x00000080,
+            /// <summary>Reserved. XP and later.</summary>
+            ICON_MASK = 0x0000000F,
+        }
+
+        /// <summary>
         /// Notify icon data structure type
         /// </summary>
         [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
@@ -321,7 +343,7 @@ namespace ManagedShell.Interop
             public uint uVersion;  // used with NIM_SETVERSION, values 0, 3 and 4
             [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 64)]
             public string szInfoTitle;
-            public uint dwInfoFlags;
+            public NIIF dwInfoFlags;
             public Guid guidItem;
             public uint hBalloonIcon;
         }

--- a/src/ManagedShell.WindowsTray/BalloonVisibility.cs
+++ b/src/ManagedShell.WindowsTray/BalloonVisibility.cs
@@ -1,0 +1,9 @@
+﻿namespace ManagedShell.WindowsTray
+{
+    public enum BalloonVisibility
+    {
+        Visible,
+        Hidden,
+        TimedOut
+    }
+}

--- a/src/ManagedShell.WindowsTray/NotificationArea.cs
+++ b/src/ManagedShell.WindowsTray/NotificationArea.cs
@@ -406,6 +406,11 @@ namespace ManagedShell.WindowsTray
 
         private void handleBalloonData(SafeNotifyIconData nicData, NotifyIcon notifyIcon)
         {
+            if (string.IsNullOrEmpty(nicData.szInfoTitle))
+            {
+                return;
+            }
+
             NotificationBalloonInfo balloonInfo = new NotificationBalloonInfo(nicData);
             NotificationBalloonEventArgs args = new NotificationBalloonEventArgs
             {

--- a/src/ManagedShell.WindowsTray/NotificationArea.cs
+++ b/src/ManagedShell.WindowsTray/NotificationArea.cs
@@ -411,17 +411,16 @@ namespace ManagedShell.WindowsTray
                 return;
             }
 
-            NotificationBalloonInfo balloonInfo = new NotificationBalloonInfo(nicData);
+            NotificationBalloon balloonInfo = new NotificationBalloon(nicData, notifyIcon);
             NotificationBalloonEventArgs args = new NotificationBalloonEventArgs
             {
-                BalloonInfo = balloonInfo,
-                NotifyIcon = notifyIcon
+                Balloon = balloonInfo
             };
+
+            ShellLogger.Debug($"NotificationArea: Received notification \"{balloonInfo.Title}\" for {notifyIcon.Title}");
 
             notifyIcon.TriggerNotificationBalloon(balloonInfo);
             NotificationBalloonShown?.Invoke(this, args);
-
-            ShellLogger.Debug($"NotificationArea: Received notification \"{balloonInfo.Title}\" for {notifyIcon.Title}");
         }
 
         // The notification area control calls this when an icon is clicked to set the placement of its host (such as for ABM_GETTASKBARPOS usage)

--- a/src/ManagedShell.WindowsTray/NotificationArea.cs
+++ b/src/ManagedShell.WindowsTray/NotificationArea.cs
@@ -419,8 +419,12 @@ namespace ManagedShell.WindowsTray
 
             ShellLogger.Debug($"NotificationArea: Received notification \"{balloonInfo.Title}\" for {notifyIcon.Title}");
 
-            notifyIcon.TriggerNotificationBalloon(balloonInfo);
             NotificationBalloonShown?.Invoke(this, args);
+
+            if (!args.Handled)
+            {
+                notifyIcon.TriggerNotificationBalloon(balloonInfo);
+            }
         }
 
         // The notification area control calls this when an icon is clicked to set the placement of its host (such as for ABM_GETTASKBARPOS usage)

--- a/src/ManagedShell.WindowsTray/NotificationBalloon.cs
+++ b/src/ManagedShell.WindowsTray/NotificationBalloon.cs
@@ -8,7 +8,7 @@ using static ManagedShell.Interop.NativeMethods;
 
 namespace ManagedShell.WindowsTray
 {
-    public class NotificationBalloonInfo
+    public class NotificationBalloon
     {
         public string Info { get; internal set; }
 
@@ -20,10 +20,14 @@ namespace ManagedShell.WindowsTray
 
         public int Timeout { get; internal set; }
 
-        public NotificationBalloonInfo() { }
+        public readonly NotifyIcon NotifyIcon;
 
-        public NotificationBalloonInfo(SafeNotifyIconData nicData)
+        public NotificationBalloon() { }
+
+        public NotificationBalloon(SafeNotifyIconData nicData, NotifyIcon notifyIcon)
         {
+            NotifyIcon = notifyIcon;
+
             Title = nicData.szInfoTitle;
             Info = nicData.szInfo;
             Flags = nicData.dwInfoFlags;
@@ -52,6 +56,29 @@ namespace ManagedShell.WindowsTray
             {
                 Icon = GetSystemIcon(SystemIcons.Error.Handle);
             }
+        }
+
+        public void SetVisibility(BalloonVisibility visibility)
+        {
+            switch (visibility)
+            {
+                case BalloonVisibility.Visible:
+                    NotifyIcon.SendMessage((uint)NIN.BALLOONSHOW, 0);
+                    break;
+                case BalloonVisibility.Hidden:
+                    NotifyIcon.SendMessage((uint)NIN.BALLOONHIDE, 0);
+                    break;
+                case BalloonVisibility.TimedOut:
+                    NotifyIcon.SendMessage((uint)NIN.BALLOONTIMEOUT, 0);
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        public void Click()
+        {
+            NotifyIcon.SendMessage((uint)NIN.BALLOONUSERCLICK, 0);
         }
 
         private void SetIconFromHIcon(IntPtr hIcon)

--- a/src/ManagedShell.WindowsTray/NotificationBalloon.cs
+++ b/src/ManagedShell.WindowsTray/NotificationBalloon.cs
@@ -20,6 +20,8 @@ namespace ManagedShell.WindowsTray
 
         public int Timeout { get; internal set; }
 
+        public DateTime Received { get; internal set; }
+
         public readonly NotifyIcon NotifyIcon;
 
         public NotificationBalloon() { }
@@ -32,6 +34,7 @@ namespace ManagedShell.WindowsTray
             Info = nicData.szInfo;
             Flags = nicData.dwInfoFlags;
             Timeout = (int)nicData.uVersion;
+            Received = DateTime.Now;
 
             if ((NIIF.USER & Flags) != 0)
             {

--- a/src/ManagedShell.WindowsTray/NotificationBalloonEventArgs.cs
+++ b/src/ManagedShell.WindowsTray/NotificationBalloonEventArgs.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace ManagedShell.WindowsTray
+{
+    public class NotificationBalloonEventArgs : EventArgs
+    {
+        public NotificationBalloonInfo BalloonInfo;
+        public NotifyIcon NotifyIcon;
+    }
+}

--- a/src/ManagedShell.WindowsTray/NotificationBalloonEventArgs.cs
+++ b/src/ManagedShell.WindowsTray/NotificationBalloonEventArgs.cs
@@ -1,10 +1,9 @@
-﻿using System;
+﻿using System.ComponentModel;
 
 namespace ManagedShell.WindowsTray
 {
-    public class NotificationBalloonEventArgs : EventArgs
+    public class NotificationBalloonEventArgs : HandledEventArgs
     {
-        public NotificationBalloonInfo BalloonInfo;
-        public NotifyIcon NotifyIcon;
+        public NotificationBalloon Balloon;
     }
 }

--- a/src/ManagedShell.WindowsTray/NotificationBalloonInfo.cs
+++ b/src/ManagedShell.WindowsTray/NotificationBalloonInfo.cs
@@ -1,0 +1,91 @@
+﻿using ManagedShell.Common.Helpers;
+using System;
+using System.Drawing;
+using System.Windows;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using static ManagedShell.Interop.NativeMethods;
+
+namespace ManagedShell.WindowsTray
+{
+    public class NotificationBalloonInfo
+    {
+        public string Info { get; internal set; }
+
+        public string Title { get; internal set; }
+
+        public NIIF Flags { get; internal set; }
+
+        public ImageSource Icon { get; internal set; }
+
+        public int Timeout { get; internal set; }
+
+        public NotificationBalloonInfo() { }
+
+        public NotificationBalloonInfo(SafeNotifyIconData nicData)
+        {
+            Title = nicData.szInfoTitle;
+            Info = nicData.szInfo;
+            Flags = nicData.dwInfoFlags;
+            Timeout = (int)nicData.uVersion;
+
+            if ((NIIF.USER & Flags) != 0)
+            {
+                if (nicData.hBalloonIcon != 0)
+                {
+                    SetIconFromHIcon((IntPtr)nicData.hBalloonIcon);
+                }
+                else if (nicData.hIcon != IntPtr.Zero)
+                {
+                    SetIconFromHIcon(nicData.hIcon);
+                }
+            }
+            else if ((NIIF.INFO & Flags) != 0)
+            {
+                Icon = GetSystemIcon(SystemIcons.Information.Handle);
+            }
+            else if ((NIIF.WARNING & Flags) != 0)
+            {
+                Icon = GetSystemIcon(SystemIcons.Warning.Handle);
+            }
+            else if ((NIIF.ERROR & Flags) != 0)
+            {
+                Icon = GetSystemIcon(SystemIcons.Error.Handle);
+            }
+        }
+
+        private void SetIconFromHIcon(IntPtr hIcon)
+        {
+            if (hIcon == IntPtr.Zero)
+            {
+                if (Icon == null)
+                {
+                    // Use default only if we don't have a valid icon already
+                    Icon = IconImageConverter.GetDefaultIcon();
+                }
+
+                return;
+            }
+
+            ImageSource icon = IconImageConverter.GetImageFromHIcon(hIcon, false);
+
+            if (icon != null)
+            {
+                Icon = icon;
+            }
+            else if (icon == null && Icon == null)
+            {
+                // Use default only if we don't have a valid icon already
+                Icon = IconImageConverter.GetDefaultIcon();
+            }
+        }
+
+        private BitmapSource GetSystemIcon(IntPtr hIcon)
+        {
+            BitmapSource bs = System.Windows.Interop.Imaging.CreateBitmapSourceFromHIcon(hIcon, Int32Rect.Empty, BitmapSizeOptions.FromEmptyOptions());
+            bs.Freeze();
+
+            return bs;
+        }
+    }
+}

--- a/src/ManagedShell.WindowsTray/NotifyIcon.cs
+++ b/src/ManagedShell.WindowsTray/NotifyIcon.cs
@@ -195,12 +195,11 @@ namespace ManagedShell.WindowsTray
 
         public event EventHandler<NotificationBalloonEventArgs> NotificationBalloonShown;
 
-        internal void TriggerNotificationBalloon(NotificationBalloonInfo balloonInfo)
+        internal void TriggerNotificationBalloon(NotificationBalloon balloonInfo)
         {
             NotificationBalloonEventArgs args = new NotificationBalloonEventArgs
             {
-                BalloonInfo = balloonInfo,
-                NotifyIcon = this
+                Balloon = balloonInfo
             };
 
             NotificationBalloonShown?.Invoke(this, args);
@@ -282,36 +281,25 @@ namespace ManagedShell.WindowsTray
         {
             if (RemoveIfInvalid()) return;
 
-            uint wparam = GetMessageWParam(mouse);
-            uint hiWord = GetMessageHiWord();
+            SendMessage((uint)WM.MOUSEHOVER, mouse);
 
-            SendNotifyMessage(HWnd, CallbackMessage, wparam, (uint)WM.MOUSEHOVER | (hiWord << 16));
-
-            if (Version > 3)
-                SendNotifyMessage(HWnd, CallbackMessage, wparam, NIN_POPUPOPEN | (hiWord << 16));
+            if (Version > 3) SendMessage((uint)NIN.POPUPOPEN, mouse);
         }
 
         public void IconMouseLeave(uint mouse)
         {
             if (RemoveIfInvalid()) return;
 
-            uint wparam = GetMessageWParam(mouse);
-            uint hiWord = GetMessageHiWord();
+            SendMessage((uint)WM.MOUSELEAVE, mouse);
 
-            SendNotifyMessage(HWnd, CallbackMessage, wparam, (uint)WM.MOUSELEAVE | (hiWord << 16));
-
-            if (Version > 3)
-                SendNotifyMessage(HWnd, CallbackMessage, wparam, NIN_POPUPCLOSE | (hiWord << 16));
+            if (Version > 3) SendMessage((uint)NIN.POPUPCLOSE, mouse);
         }
 
         public void IconMouseMove(uint mouse)
         {
             if (RemoveIfInvalid()) return;
 
-            uint wparam = GetMessageWParam(mouse);
-            uint hiWord = GetMessageHiWord();
-
-            SendNotifyMessage(HWnd, CallbackMessage, wparam, (uint)WM.MOUSEMOVE | (hiWord << 16));
+            SendMessage((uint)WM.MOUSEMOVE, mouse);
         }
 
         public void IconMouseDown(MouseButton button, uint mouse, int doubleClickTime)
@@ -320,18 +308,15 @@ namespace ManagedShell.WindowsTray
             GetWindowThreadProcessId(HWnd, out uint procId);
             AllowSetForegroundWindow(procId);
 
-            uint wparam = GetMessageWParam(mouse);
-            uint hiWord = GetMessageHiWord();
-
             if (button == MouseButton.Left)
             {
                 if (DateTime.Now.Subtract(_lastLClick).TotalMilliseconds <= doubleClickTime)
                 {
-                    SendNotifyMessage(HWnd, CallbackMessage, wparam, (uint)WM.LBUTTONDBLCLK | (hiWord << 16));
+                    SendMessage((uint)WM.LBUTTONDBLCLK, mouse);
                 }
                 else
                 {
-                    SendNotifyMessage(HWnd, CallbackMessage, wparam, (uint)WM.LBUTTONDOWN | (hiWord << 16));
+                    SendMessage((uint)WM.LBUTTONDOWN, mouse);
                 }
 
                 _lastLClick = DateTime.Now;
@@ -340,11 +325,11 @@ namespace ManagedShell.WindowsTray
             {
                 if (DateTime.Now.Subtract(_lastRClick).TotalMilliseconds <= doubleClickTime)
                 {
-                    SendNotifyMessage(HWnd, CallbackMessage, wparam, (uint)WM.RBUTTONDBLCLK | (hiWord << 16));
+                    SendMessage((uint)WM.RBUTTONDBLCLK, mouse);
                 }
                 else
                 {
-                    SendNotifyMessage(HWnd, CallbackMessage, wparam, (uint)WM.RBUTTONDOWN | (hiWord << 16));
+                    SendMessage((uint)WM.RBUTTONDOWN, mouse);
                 }
 
                 _lastRClick = DateTime.Now;
@@ -355,27 +340,29 @@ namespace ManagedShell.WindowsTray
         {
             ShellLogger.Debug($"NotifyIcon: {button} mouse button clicked: {Title}");
 
-            uint wparam = GetMessageWParam(mouse);
-            uint hiWord = GetMessageHiWord();
-
             if (button == MouseButton.Left)
             {
-                SendNotifyMessage(HWnd, CallbackMessage, wparam, (uint)WM.LBUTTONUP | (hiWord << 16));
+                SendMessage((uint)WM.LBUTTONUP, mouse);
 
                 // This is documented as version 4, but Explorer does this for version 3 as well
-                if (Version >= 3) SendNotifyMessage(HWnd, CallbackMessage, wparam, NIN_SELECT | (hiWord << 16));
+                if (Version >= 3) SendMessage((uint)NIN.SELECT, mouse);
 
                 _lastLClick = DateTime.Now;
             }
             else if (button == MouseButton.Right)
             {
-                SendNotifyMessage(HWnd, CallbackMessage, wparam, (uint)WM.RBUTTONUP | (hiWord << 16));
+                SendMessage((uint)WM.RBUTTONUP, mouse);
 
                 // This is documented as version 4, but Explorer does this for version 3 as well
-                if (Version >= 3) SendNotifyMessage(HWnd, CallbackMessage, wparam, (uint)WM.CONTEXTMENU | (hiWord << 16));
+                if (Version >= 3) SendMessage((uint)WM.CONTEXTMENU, mouse);
 
                 _lastRClick = DateTime.Now;
             }
+        }
+
+        internal bool SendMessage(uint message, uint mouse)
+        {
+            return SendNotifyMessage(HWnd, CallbackMessage, GetMessageWParam(mouse), message | (GetMessageHiWord() << 16));
         }
 
         private uint GetMessageHiWord()

--- a/src/ManagedShell.WindowsTray/NotifyIcon.cs
+++ b/src/ManagedShell.WindowsTray/NotifyIcon.cs
@@ -7,6 +7,7 @@ using static ManagedShell.Interop.NativeMethods;
 using ManagedShell.Common.Logging;
 using System.Collections.Generic;
 using System.Linq;
+using System.Collections.ObjectModel;
 
 namespace ManagedShell.WindowsTray
 {
@@ -33,6 +34,7 @@ namespace ManagedShell.WindowsTray
         {
             _notificationArea = notificationArea;
             HWnd = hWnd;
+            MissedNotifications = new ObservableCollection<NotificationBalloon>();
         }
 
         private ImageSource _icon;
@@ -193,6 +195,12 @@ namespace ManagedShell.WindowsTray
 
         #region Balloon Notifications
 
+        public ObservableCollection<NotificationBalloon> MissedNotifications
+        {
+            get;
+            set;
+        }
+
         public event EventHandler<NotificationBalloonEventArgs> NotificationBalloonShown;
 
         internal void TriggerNotificationBalloon(NotificationBalloon balloonInfo)
@@ -203,6 +211,11 @@ namespace ManagedShell.WindowsTray
             };
 
             NotificationBalloonShown?.Invoke(this, args);
+
+            if (!args.Handled)
+            {
+                MissedNotifications.Add(balloonInfo);
+            }
         }
 
         #endregion

--- a/src/ManagedShell.WindowsTray/NotifyIcon.cs
+++ b/src/ManagedShell.WindowsTray/NotifyIcon.cs
@@ -191,6 +191,23 @@ namespace ManagedShell.WindowsTray
             }
         }
 
+        #region Balloon Notifications
+
+        public event EventHandler<NotificationBalloonEventArgs> NotificationBalloonShown;
+
+        internal void TriggerNotificationBalloon(NotificationBalloonInfo balloonInfo)
+        {
+            NotificationBalloonEventArgs args = new NotificationBalloonEventArgs
+            {
+                BalloonInfo = balloonInfo,
+                NotifyIcon = this
+            };
+
+            NotificationBalloonShown?.Invoke(this, args);
+        }
+
+        #endregion
+
         #region Pinning
 
         public void Pin()

--- a/src/ManagedShell.WindowsTray/SafeNotifyIconData.cs
+++ b/src/ManagedShell.WindowsTray/SafeNotifyIconData.cs
@@ -18,7 +18,7 @@ namespace ManagedShell.WindowsTray
         public string szInfo;
         public uint uVersion;  // used with NIM_SETVERSION, values 0, 3 and 4
         public string szInfoTitle;
-        public uint dwInfoFlags;
+        public NIIF dwInfoFlags;
         public Guid guidItem;
         public uint hBalloonIcon;
 


### PR DESCRIPTION
- `NotificationBalloon` class represents the received notification
- 2 new events that the consuming shell can subscribe to:
  - `NotificationArea.NotificationBalloonShown` => Runs for every received notification
  - `NotifyIcon.NotificationBalloonShown` => Runs for the `NotifyIcon` associated to the notification if the above event was not handled
- If no balloon event is handled, the notification is added to the `NotifyIcon.MissedNotifications` collection
- Methods for sending `NIN_*` messages that applications expect after providing a notification
- Misc refactors