### PR TITLE
Notification balloon fixes

### DIFF
--- a/src/ManagedShell.Common/Helpers/SoundHelper.cs
+++ b/src/ManagedShell.Common/Helpers/SoundHelper.cs
@@ -61,10 +61,25 @@ namespace ManagedShell.Common.Helpers
         /// </summary>
         public static void PlayNotificationSound()
         {
+            // System default sound for the classic notification balloon.
             if (!PlaySystemSound("Explorer", "SystemNotification"))
             {
-                PlaySystemSound(".Default", "SystemNotification");
+                if (EnvironmentHelper.IsWindows8OrBetter)
+                {
+                    // Toast notification sound.
+                    if (!PlaySystemSound(".Default", "Notification.Default"))
+                        PlayXPNotificationSound();
+                }
+                else
+                {
+                    PlayXPNotificationSound();
+                }
             }
+        }
+
+        public static bool PlayXPNotificationSound()
+        {
+            return PlaySystemSound(".Default", "SystemNotification");
         }
     }
 }

--- a/src/ManagedShell.WindowsTray/NotificationBalloon.cs
+++ b/src/ManagedShell.WindowsTray/NotificationBalloon.cs
@@ -37,28 +37,30 @@ namespace ManagedShell.WindowsTray
             Timeout = (int)nicData.uVersion;
             Received = DateTime.Now;
 
-            if ((NIIF.USER & Flags) != 0)
+            switch (Flags)
             {
-                if (nicData.hBalloonIcon != 0)
-                {
-                    SetIconFromHIcon((IntPtr)nicData.hBalloonIcon);
-                }
-                else if (nicData.hIcon != IntPtr.Zero)
-                {
-                    SetIconFromHIcon(nicData.hIcon);
-                }
-            }
-            else if ((NIIF.INFO & Flags) != 0)
-            {
-                Icon = GetSystemIcon(SystemIcons.Information.Handle);
-            }
-            else if ((NIIF.WARNING & Flags) != 0)
-            {
-                Icon = GetSystemIcon(SystemIcons.Warning.Handle);
-            }
-            else if ((NIIF.ERROR & Flags) != 0)
-            {
-                Icon = GetSystemIcon(SystemIcons.Error.Handle);
+                case NIIF.USER:
+                    if (nicData.hBalloonIcon != 0)
+                    {
+                        SetIconFromHIcon((IntPtr)nicData.hBalloonIcon);
+                    }
+                    else if (nicData.hIcon != IntPtr.Zero)
+                    {
+                        SetIconFromHIcon(nicData.hIcon);
+                    }
+                    break;
+
+                case NIIF.INFO:
+                    Icon = GetSystemIcon(SystemIcons.Information.Handle);
+                    break;
+
+                case NIIF.WARNING:
+                    Icon = GetSystemIcon(SystemIcons.Warning.Handle);
+                    break;
+
+                case NIIF.ERROR:
+                    Icon = GetSystemIcon(SystemIcons.Error.Handle);
+                    break;
             }
         }
 

--- a/src/ManagedShell.WindowsTray/NotificationBalloon.cs
+++ b/src/ManagedShell.WindowsTray/NotificationBalloon.cs
@@ -37,30 +37,28 @@ namespace ManagedShell.WindowsTray
             Timeout = (int)nicData.uVersion;
             Received = DateTime.Now;
 
-            switch (Flags)
+            if (Flags.HasFlag(NIIF.ERROR))
             {
-                case NIIF.USER:
-                    if (nicData.hBalloonIcon != 0)
-                    {
-                        SetIconFromHIcon((IntPtr)nicData.hBalloonIcon);
-                    }
-                    else if (nicData.hIcon != IntPtr.Zero)
-                    {
-                        SetIconFromHIcon(nicData.hIcon);
-                    }
-                    break;
-
-                case NIIF.INFO:
-                    Icon = GetSystemIcon(SystemIcons.Information.Handle);
-                    break;
-
-                case NIIF.WARNING:
-                    Icon = GetSystemIcon(SystemIcons.Warning.Handle);
-                    break;
-
-                case NIIF.ERROR:
-                    Icon = GetSystemIcon(SystemIcons.Error.Handle);
-                    break;
+                Icon = GetSystemIcon(SystemIcons.Error.Handle);
+            }
+            else if (Flags.HasFlag(NIIF.INFO))
+            {
+                Icon = GetSystemIcon(SystemIcons.Information.Handle);
+            }
+            else if (Flags.HasFlag(NIIF.WARNING))
+            {
+                Icon = GetSystemIcon(SystemIcons.Warning.Handle);
+            }
+            else if (Flags.HasFlag(NIIF.USER))
+            {
+                if (nicData.hBalloonIcon != 0)
+                {
+                    SetIconFromHIcon((IntPtr)nicData.hBalloonIcon);
+                }
+                else if (nicData.hIcon != IntPtr.Zero)
+                {
+                    SetIconFromHIcon(nicData.hIcon);
+                }
             }
         }
 


### PR DESCRIPTION
Makes minor fixes in #36 (uses the correct audio session for system notifications, used to use the application's own), and #35 (uses the correct icons to display in the tooltip balloon, used to fail to display the error icon showing the info icon instead).