### PR TITLE
Add Windows 11 support for notification icons and dark mode

### DIFF
--- a/src/ManagedShell.Common/Helpers/EnvironmentHelper.cs
+++ b/src/ManagedShell.Common/Helpers/EnvironmentHelper.cs
@@ -96,6 +96,19 @@ namespace ManagedShell.Common.Helpers
             }
         }
 
+        public static bool IsWindows11OrBetter
+        {
+            get
+            {
+                if (osVersionMajor == 0)
+                {
+                    getOSVersion();
+                }
+
+                return (osVersionMajor >= 10 && osVersionBuild >= 22000);
+            }
+        }
+
         public static bool IsWindows10DarkModeSupported
         {
             get
@@ -111,7 +124,7 @@ namespace ManagedShell.Common.Helpers
                 }
 
                 // This has an upper-bound due to the volatility of the undocumented dark mode API
-                return (osVersionMajor >= 10 && osVersionBuild >= 18362 && osVersionBuild <= 19043);
+                return (osVersionMajor >= 10 && osVersionBuild >= 18362 && osVersionBuild <= 22000);
             }
         }
 

--- a/src/ManagedShell.Common/Helpers/ShellHelper.cs
+++ b/src/ManagedShell.Common/Helpers/ShellHelper.cs
@@ -267,6 +267,16 @@ namespace ManagedShell.Common.Helpers
             ShellKeyCombo(VK_LWIN, 0x41);
         }
 
+        public static void ShowNotificationCenter()
+        {
+            if (!EnvironmentHelper.IsWindows11OrBetter)
+            {
+                return;
+            }
+
+            ShellKeyCombo(VK_LWIN, 0x4E);
+        }
+
         public static void ShowStartMenu()
         {
             ShellKeyCombo(VK_LWIN, VK_LWIN);

--- a/src/ManagedShell.WindowsTray/NotificationArea.cs
+++ b/src/ManagedShell.WindowsTray/NotificationArea.cs
@@ -2,6 +2,7 @@
 using ManagedShell.Common.Logging;
 using ManagedShell.Interop;
 using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel;
@@ -23,6 +24,13 @@ namespace ManagedShell.WindowsTray
             HEALTH_GUID,
             POWER_GUID,
             NETWORK_GUID,
+            VOLUME_GUID
+        };
+
+        internal static readonly List<string> Win11ActionCenterIcons = new List<string>()
+        {
+            NETWORK_GUID,
+            POWER_GUID,
             VOLUME_GUID
         };
 

--- a/src/ManagedShell.WindowsTray/NotifyIcon.cs
+++ b/src/ManagedShell.WindowsTray/NotifyIcon.cs
@@ -8,6 +8,7 @@ using ManagedShell.Common.Logging;
 using System.Collections.Generic;
 using System.Linq;
 using System.Collections.ObjectModel;
+using ManagedShell.Common.Helpers;
 
 namespace ManagedShell.WindowsTray
 {
@@ -17,7 +18,6 @@ namespace ManagedShell.WindowsTray
     public class NotifyIcon : IEquatable<NotifyIcon>, INotifyPropertyChanged
     {
         private readonly NotificationArea _notificationArea;
-
 
         /// <summary>
         /// Initializes a new instance of the TrayIcon class with no hwnd.
@@ -323,6 +323,11 @@ namespace ManagedShell.WindowsTray
 
             if (button == MouseButton.Left)
             {
+                if (handleClickOverride(false))
+                {
+                    return;
+                }
+
                 if (DateTime.Now.Subtract(_lastLClick).TotalMilliseconds <= doubleClickTime)
                 {
                     SendMessage((uint)WM.LBUTTONDBLCLK, mouse);
@@ -355,6 +360,11 @@ namespace ManagedShell.WindowsTray
 
             if (button == MouseButton.Left)
             {
+                if (handleClickOverride(true))
+                {
+                    return;
+                }
+
                 SendMessage((uint)WM.LBUTTONUP, mouse);
 
                 // This is documented as version 4, but Explorer does this for version 3 as well
@@ -403,6 +413,21 @@ namespace ManagedShell.WindowsTray
             if (!IsWindow(HWnd))
             {
                 _notificationArea.TrayIcons.Remove(this);
+                return true;
+            }
+
+            return false;
+        }
+
+        private bool handleClickOverride(bool performAction)
+        {
+            if (NotificationArea.Win11ActionCenterIcons.Contains(GUID.ToString()) && EnvironmentHelper.IsWindows11OrBetter)
+            {
+                if (performAction)
+                {
+                    ShellHelper.ShowActionCenter();
+                }
+
                 return true;
             }
 


### PR DESCRIPTION
In Windows 11, the power/network/volume notification area icons open Action Center; this PR causes clicking those icons to simply execute the Action Center shortcut, as the legacy icons do nothing otherwise.

Also added a Notification Center shortcut, which is what appears when the clock is clicked in Windows 11.