### PR TITLE
Change task category provider after initialization

### DIFF
--- a/src/ManagedShell.WindowsTasks/ITaskCategoryProvider.cs
+++ b/src/ManagedShell.WindowsTasks/ITaskCategoryProvider.cs
@@ -4,8 +4,18 @@ namespace ManagedShell.WindowsTasks
 {
     public interface ITaskCategoryProvider : IDisposable
     {
+        /// <summary>
+        /// Called by ApplicationWindow to request its category.
+        /// </summary>
+        /// <param name="window">ApplicationWindow to get category for</param>
+        /// <returns>Category</returns>
         string GetCategory(ApplicationWindow window);
 
+        /// <summary>
+        /// Provides the ITaskCategoryProvider with delegate to call when ApplicationWindow
+        /// categories need to be re-evaluated.
+        /// </summary>
+        /// <param name="changeDelegate">Delegate to call when categories change</param>
         void SetCategoryChangeDelegate(TaskCategoryChangeDelegate changeDelegate);
     }
 }

--- a/src/ManagedShell.WindowsTasks/Tasks.cs
+++ b/src/ManagedShell.WindowsTasks/Tasks.cs
@@ -34,7 +34,7 @@ namespace ManagedShell.WindowsTasks
         {
             if (!_tasksService.IsInitialized)
             {
-                _tasksService.SetTaskCategoryProvider(taskCategoryProvider);
+                SetTaskCategoryProvider(taskCategoryProvider);
                 Initialize();
             }
         }
@@ -42,6 +42,16 @@ namespace ManagedShell.WindowsTasks
         public void Initialize()
         {
             _tasksService.Initialize();
+        }
+
+        public void SetTaskCategoryProvider(ITaskCategoryProvider taskCategoryProvider)
+        {
+            if (_tasksService.TaskCategoryProvider != null)
+            {
+                _tasksService.TaskCategoryProvider.Dispose();
+            }
+
+            _tasksService.SetTaskCategoryProvider(taskCategoryProvider);
         }
 
         private void groupedWindows_Changed(object sender, NotifyCollectionChangedEventArgs e)


### PR DESCRIPTION
Allows shells to change the task category provider without having to re-initialize the tasks service. Also added some comments to clarify `ITaskCategoryProvider`.