### PR TITLE
Handle AppBar state requests

### DIFF
--- a/src/ManagedShell.AppBar/AppBarManager.cs
+++ b/src/ManagedShell.AppBar/AppBarManager.cs
@@ -5,6 +5,7 @@ using System.Runtime.InteropServices;
 using System.Windows.Forms;
 using ManagedShell.Common.Helpers;
 using static ManagedShell.Interop.NativeMethods;
+using ManagedShell.WindowsTray;
 
 namespace ManagedShell.AppBar
 {
@@ -13,14 +14,18 @@ namespace ManagedShell.AppBar
         private static object appBarLock = new object();
         
         private readonly ExplorerHelper _explorerHelper;
+        private AutoHideBarDelegate _autoHideBarDelegate;
         private int uCallBack;
-        
+
         public List<AppBarWindow> AppBars { get; } = new List<AppBarWindow>();
         public EventHandler<AppBarEventArgs> AppBarEvent;
 
         public AppBarManager(ExplorerHelper explorerHelper)
         {
+            _autoHideBarDelegate = autoHideBarDelegate;
             _explorerHelper = explorerHelper;
+
+            _explorerHelper._notificationArea.SetAutoHideBarCallback(_autoHideBarDelegate);
         }
 
         public void SignalGracefulShutdown()
@@ -35,6 +40,13 @@ namespace ManagedShell.AppBar
         {
             AppBarEventArgs args = new AppBarEventArgs { Reason = reason };
             AppBarEvent?.Invoke(sender, args);
+        }
+
+        private IntPtr autoHideBarDelegate(ABEdge? edge)
+        {
+            // AppBarWindow does not currently manage auto-hide, it is the responsibility of the shell.
+            // This should be implemented in the future to allow apps to check if there are any auto-hide bars.
+            return IntPtr.Zero;
         }
 
         #region AppBar message helpers

--- a/src/ManagedShell.Interop/NativeMethods.Shell32.cs
+++ b/src/ManagedShell.Interop/NativeMethods.Shell32.cs
@@ -34,12 +34,20 @@ namespace ManagedShell.Interop
             ABM_WINDOWPOSCHANGED,
             ABM_SETSTATE
         }
+
         public enum ABEdge : int
         {
             ABE_LEFT = 0,
             ABE_TOP,
             ABE_RIGHT,
             ABE_BOTTOM
+        }
+
+        public enum ABState : int
+        {
+            Default = 0,
+            AutoHide,
+            OnTop
         }
 
         public enum AppBarNotifications

--- a/src/ManagedShell.WindowsTray/Delegates.cs
+++ b/src/ManagedShell.WindowsTray/Delegates.cs
@@ -26,4 +26,11 @@ namespace ManagedShell.WindowsTray
     /// </summary>
     /// <returns>Indication of message outcome.</returns>
     public delegate TrayHostSizeData TrayHostSizeDelegate();
+
+    /// <summary>
+    /// Delegate signature for the AppBar autohide callback.
+    /// </summary>
+    /// <param name="edge">The AppBar edge to check for an autohide bar. Null to check any edge.</param>
+    /// <returns>Window handle to the autohide AppBar.</returns>
+    public delegate IntPtr AutoHideBarDelegate(ABEdge? edge);
 }

--- a/src/ManagedShell.WindowsTray/NotificationArea.cs
+++ b/src/ManagedShell.WindowsTray/NotificationArea.cs
@@ -48,6 +48,7 @@ namespace ManagedShell.WindowsTray
 
         public event EventHandler<NotificationBalloonEventArgs> NotificationBalloonShown;
 
+        private AutoHideBarDelegate autoHideBarDelegate;
         private SystrayDelegate trayDelegate;
         private IconDataDelegate iconDataDelegate;
         private TrayHostSizeDelegate trayHostSizeDelegate;
@@ -440,6 +441,18 @@ namespace ManagedShell.WindowsTray
         {
             trayHostSizeData = data;
             _trayService?.SetTrayHostSizeData(trayHostSizeData);
+        }
+
+        // The AppBarManager calls this to provide AppBar autohide information
+        public void SetAutoHideBarCallback(AutoHideBarDelegate theDelegate)
+        {
+            if (theDelegate == null)
+            {
+                return;
+            }
+
+            autoHideBarDelegate = theDelegate;
+            _trayService?.SetAutoHideBarCallback(autoHideBarDelegate);
         }
 
         public void Dispose()


### PR DESCRIPTION
Fixes apps incorrectly thinking the taskbar is auto-hide.

Some apps, notably Firefox and Chromium-based apps, add a few pixels to the edge of their window if the taskbar is set to auto-hide (presumably to prevent the 2 pixels of remaining taskbar from covering the browser). Currently, when a ManagedShell app is running, the request gets forwarded to Explorer, which has an auto-hidden taskbar, so apps always think that auto-hide is enabled.

This PR causes ManagedShell to handle ABM_GETSTATE and ABM_GETAUTOHIDEBAR messages, which is what apps use to tell if the taskbar is auto-hidden.

I added plumbing for AppBarManager to provide information regarding AppBarWindows that are autohidden, however AppBarWindow doesn't currently have a concept of auto-hide, so effectively this always returns the default (no auto-hide).

In the future when AppBarWindows track auto-hide state, AppBarManager can be updated to return the appropriate auto-hidden AppBar window handle.

This fixes items in the following GitHub issues:

- cairoshell/cairoshell#356
- cairoshell/cairoshell#401
- dremin/retrobar#53