### PR TITLE
Consolidate StartProcess, add EntryPoint to StoreApp

### DIFF
--- a/src/ManagedShell.Common/Enums/ShellFolderPath.cs
+++ b/src/ManagedShell.Common/Enums/ShellFolderPath.cs
@@ -1,4 +1,4 @@
-﻿namespace ManagedShell.ShellFolders.Enums
+﻿namespace ManagedShell.Common.Enums
 {
     public class ShellFolderPath
     {

--- a/src/ManagedShell.UWPInterop/StoreApp.cs
+++ b/src/ManagedShell.UWPInterop/StoreApp.cs
@@ -12,6 +12,7 @@ namespace ManagedShell.UWPInterop
     {
         public readonly string AppUserModelId;
         public string DisplayName;
+        public string EntryPoint;
         public string IconColor;
 
         public string SmallIconPath;

--- a/src/ManagedShell.UWPInterop/StoreAppHelper.cs
+++ b/src/ManagedShell.UWPInterop/StoreAppHelper.cs
@@ -105,7 +105,8 @@ namespace ManagedShell.UWPInterop
                 LargeIconPath = icons[IconSize.Large],
                 ExtraLargeIconPath = icons[IconSize.ExtraLarge],
                 JumboIconPath = icons[IconSize.Jumbo],
-                IconColor = getPlateColor(icons[IconSize.Small], appNode, xmlnsManager)
+                IconColor = getPlateColor(icons[IconSize.Small], appNode, xmlnsManager),
+                EntryPoint = getEntryPoint(appNode, xmlnsManager)
             };
 
             return storeApp;
@@ -177,6 +178,11 @@ namespace ManagedShell.UWPInterop
                 return name;
 
             return ExtractStringFromPRIFile(packagePath + "\\resources.pri", nameUri.ToString());
+        }
+
+        private static string getEntryPoint(XmlNode app, XmlNamespaceManager xmlnsManager)
+        {
+            return app.SelectSingleNode("@EntryPoint", xmlnsManager)?.Value;
         }
 
         private static string getPlateColor(string iconPath, XmlNode app, XmlNamespaceManager xmlnsManager)


### PR DESCRIPTION
Also change UWP apps to run directly from `shell:appsfolder`.

These changes will allow shells to run eligible UWP apps as admin (cairoshell/cairoshell#605)