### PR TITLE
Set working directory

### DIFF
--- a/src/ManagedShell.AppBar/AppBarWindow.cs
+++ b/src/ManagedShell.AppBar/AppBarWindow.cs
@@ -287,8 +287,8 @@ namespace ManagedShell.AppBar
         {
             Top = rect.Top / DpiScale;
             Left = rect.Left / DpiScale;
-            Width = (rect.Right - rect.Left) / DpiScale;
-            Height = (rect.Bottom - rect.Top) / DpiScale;
+            if (rect.Width >= 0) Width = rect.Width / DpiScale;
+            if (rect.Height >= 0) Height = rect.Height / DpiScale;
         }
 
         private void ProcessScreenChange(ScreenSetupReason reason)

--- a/src/ManagedShell.Common/Helpers/ShellHelper.cs
+++ b/src/ManagedShell.Common/Helpers/ShellHelper.cs
@@ -53,7 +53,7 @@ namespace ManagedShell.Common.Helpers
             }
         }
 
-        public static bool StartProcess(string filename, string args = "", string verb = "")
+        public static bool StartProcess(string filename, string args = "", string verb = "", string workingDirectory = "")
         {
             try
             {
@@ -83,7 +83,8 @@ namespace ManagedShell.Common.Helpers
                     UseShellExecute = true,
                     FileName = filename,
                     Arguments = args,
-                    Verb = verb
+                    Verb = verb,
+                    WorkingDirectory = workingDirectory
                 };
 
                 Process.Start(psi);

--- a/src/ManagedShell.ShellFolders/ShellContextMenu.cs
+++ b/src/ManagedShell.ShellFolders/ShellContextMenu.cs
@@ -151,15 +151,17 @@ namespace ManagedShell.ShellFolders
         /// Invokes a specific command from an IContextMenu
         /// </summary>
         /// <param name="iContextMenu">the IContextMenu containing the item</param>
+        /// <param name="workingDir">the parent directory from where to invoke</param>
         /// <param name="cmd">the index of the command to invoke</param>
-        /// <param name="parentDir">the parent directory from where to invoke</param>
         /// <param name="ptInvoke">the point (in screen coordinates) from which to invoke</param>
-        protected void InvokeCommand(IContextMenu iContextMenu, uint cmd, Point ptInvoke)
+        protected void InvokeCommand(IContextMenu iContextMenu, string workingDir, uint cmd, Point ptInvoke)
         {
             CMINVOKECOMMANDINFOEX invoke = new CMINVOKECOMMANDINFOEX();
             invoke.cbSize = Interop.cbInvokeCommand;
             invoke.lpVerb = (IntPtr)cmd;
             invoke.lpVerbW = (IntPtr)cmd;
+            invoke.lpDirectory = workingDir;
+            invoke.lpDirectoryW = workingDir;
             invoke.fMask = CMIC.ASYNCOK | CMIC.FLAG_LOG_USAGE | CMIC.UNICODE | CMIC.PTINVOKE |
                 ((Control.ModifierKeys & Keys.Control) != 0 ? CMIC.CONTROL_DOWN : 0) |
                 ((Control.ModifierKeys & Keys.Shift) != 0 ? CMIC.SHIFT_DOWN : 0);

--- a/src/ManagedShell.ShellFolders/ShellFolderContextMenu.cs
+++ b/src/ManagedShell.ShellFolders/ShellFolderContextMenu.cs
@@ -105,7 +105,7 @@ namespace ManagedShell.ShellFolders
                         {
                             InvokeCommand(
                                 subMenu.iContextMenu,
-                                folder.Path,
+                                folder.IsFolder && folder.IsFileSystem ? folder.Path : null,
                                 selected - Interop.CMD_FIRST,
                                 new Point(x, y));
                         }

--- a/src/ManagedShell.ShellFolders/ShellFolderContextMenu.cs
+++ b/src/ManagedShell.ShellFolders/ShellFolderContextMenu.cs
@@ -105,6 +105,7 @@ namespace ManagedShell.ShellFolders
                         {
                             InvokeCommand(
                                 subMenu.iContextMenu,
+                                folder.Path,
                                 selected - Interop.CMD_FIRST,
                                 new Point(x, y));
                         }

--- a/src/ManagedShell.ShellFolders/ShellItemContextMenu.cs
+++ b/src/ManagedShell.ShellFolders/ShellItemContextMenu.cs
@@ -202,7 +202,7 @@ namespace ManagedShell.ShellFolders
                     return;
                 }
 
-                if (files.Length > 0 && files[0].ParentItem != null)
+                if (files.Length > 0 && files[0].ParentItem != null && files[0].ParentItem.IsFolder && files[0].ParentItem.IsFileSystem)
                 {
                     workingDir = files[0].ParentItem.Path;
                 }

--- a/src/ManagedShell.ShellFolders/ShellItemContextMenu.cs
+++ b/src/ManagedShell.ShellFolders/ShellItemContextMenu.cs
@@ -189,6 +189,7 @@ namespace ManagedShell.ShellFolders
             if (selected >= Interop.CMD_FIRST && selected < uint.MaxValue)
             {
                 string command = GetCommandString(iContextMenu, selected - Interop.CMD_FIRST, true);
+                string workingDir = null;
 
                 if (string.IsNullOrEmpty(command))
                 {
@@ -201,8 +202,14 @@ namespace ManagedShell.ShellFolders
                     return;
                 }
 
+                if (files.Length > 0 && files[0].ParentItem != null)
+                {
+                    workingDir = files[0].ParentItem.Path;
+                }
+
                 InvokeCommand(
                     iContextMenu,
+                    workingDir,
                     selected - Interop.CMD_FIRST,
                     new Point(x, y));
             }


### PR DESCRIPTION
Sets the working directory for commands executed via `IContextMenu` from filesystem folders, and adds the ability to set it from `ShellHelper.StartProcess`.

This is needed to take care of cairoshell/cairoshell#640.

Also includes a drive-by fix to prevent an exception when AppBar gives us negative dimensions.