### PR TITLE
Fix AppBar sanity checking to properly handle vertical AppBars

### DIFF
--- a/src/ManagedShell.AppBar/AppBarManager.cs
+++ b/src/ManagedShell.AppBar/AppBarManager.cs
@@ -251,7 +251,8 @@ namespace ManagedShell.AppBar
 
                 abWindow.AfterAppBarPos(isSameCoords, abd.rc);
 
-                if (abd.rc.Bottom - abd.rc.Top < sHeight)
+                if (((abd.uEdge == (int)AppBarEdge.Top || abd.uEdge == (int)AppBarEdge.Bottom) && abd.rc.Bottom - abd.rc.Top < sHeight) ||
+                    ((abd.uEdge == (int)AppBarEdge.Left || abd.uEdge == (int)AppBarEdge.Right) && abd.rc.Right - abd.rc.Left < sWidth))
                 {
                     ABSetPos(abWindow, width, height, edge);
                 }


### PR DESCRIPTION
At the end of ABSetPos, we check if the AppBar's resulting height is the desired height. This was correct when we only supported horizontal AppBars, but causes an infinite loop for vertical AppBars when another horizontal AppBar is present (dremin/retrobar#186).

This changes the sanity check to check the resulting width for vertical AppBars rather than height.