### PR TITLE
Fix AppBar shared memory handling, remove workarounds

### DIFF
--- a/src/ManagedShell.AppBar/ExplorerHelper.cs
+++ b/src/ManagedShell.AppBar/ExplorerHelper.cs
@@ -2,7 +2,6 @@
 using ManagedShell.WindowsTray;
 using System;
 using System.Runtime.InteropServices;
-using System.Threading.Tasks;
 using System.Windows.Threading;
 using ManagedShell.Common.Logging;
 using static ManagedShell.Interop.NativeMethods;
@@ -52,18 +51,6 @@ namespace ManagedShell.AppBar
             SetupTaskbarMonitor();
         }
 
-        public void SuspendTrayService()
-        {
-            // get Explorer tray window back so we can do appbar stuff that requires shared memory
-            _notificationArea?.Suspend();
-        }
-
-        public void ResumeTrayService()
-        {
-            // take back over
-            _notificationArea?.Resume();
-        }
-
         public void SetTaskbarVisibility(int swp)
         {
             // only run this if our TaskBar is enabled, or if we are showing the Windows TaskBar
@@ -105,17 +92,14 @@ namespace ManagedShell.AppBar
 
         public void SetTaskbarState(ABState state)
         {
-            Task.Run(() =>
+            APPBARDATA abd = new APPBARDATA
             {
-                APPBARDATA abd = new APPBARDATA
-                {
-                    cbSize = Marshal.SizeOf(typeof(APPBARDATA)),
-                    hWnd = WindowHelper.FindWindowsTray(_notificationArea.Handle),
-                    lParam = (IntPtr)state
-                };
+                cbSize = Marshal.SizeOf(typeof(APPBARDATA)),
+                hWnd = WindowHelper.FindWindowsTray(_notificationArea.Handle),
+                lParam = (IntPtr)state
+            };
 
-                SHAppBarMessage((int)ABMsg.ABM_SETSTATE, ref abd);
-            });
+            SHAppBarMessage((int)ABMsg.ABM_SETSTATE, ref abd);
         }
 
         public ABState GetTaskbarState()
@@ -126,10 +110,7 @@ namespace ManagedShell.AppBar
                 hWnd = WindowHelper.FindWindowsTray(_notificationArea.Handle)
             };
 
-            // suspend tray since we don't care about ManagedShell AppBars here
-            SuspendTrayService();
             uint uState = SHAppBarMessage((int)ABMsg.ABM_GETSTATE, ref abd);
-            ResumeTrayService();
 
             return (ABState)uState;
         }

--- a/src/ManagedShell.Interop/NativeMethods.Shell32.cs
+++ b/src/ManagedShell.Interop/NativeMethods.Shell32.cs
@@ -20,6 +20,28 @@ namespace ManagedShell.Interop
             public IntPtr lParam;
         }
 
+        [StructLayout(LayoutKind.Sequential)]
+        public struct APPBARDATAV2
+        {
+            public int cbSize;
+            public uint hWnd;
+            public uint uCallbackMessage;
+            public uint uEdge;
+            public Rect rc;
+            public long lParam;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct APPBARMSGDATAV3
+        {
+            public APPBARDATAV2 abd;
+            public int dwMessage;
+            public int dwPadding1;
+            public long hSharedMemory;
+            public int dwSourceProcessId;
+            public int dwPadding3;
+        }
+
         public enum ABMsg : int
         {
             ABM_NEW = 0,
@@ -381,30 +403,6 @@ namespace ManagedShell.Interop
             public uint hWnd;
             public uint uID;
             public Guid guidItem;
-        }
-
-        [StructLayout(LayoutKind.Sequential)]
-        public struct APPBARDATAV2
-        {
-            public int cbSize;
-            public uint hWnd;
-            public uint uCallbackMessage;
-            public uint uEdge;
-            public Rect rc;
-            public int lParam;
-            public int dw64BitAlign;
-        }
-
-        [StructLayout(LayoutKind.Sequential)]
-        public struct APPBARMSGDATAV3
-        {
-            public APPBARDATAV2 abd;
-            public int dwMessage;
-            public int dwPadding1;
-            public uint hSharedMemory;
-            public int dwPadding2;
-            public int dwSourceProcessId;
-            public int dwPadding3;
         }
 
         [StructLayout(LayoutKind.Sequential, Pack = 4)]

--- a/src/ManagedShell.Interop/NativeMethods.ShlwApi.cs
+++ b/src/ManagedShell.Interop/NativeMethods.ShlwApi.cs
@@ -8,6 +8,12 @@ namespace ManagedShell.Interop
         const string ShlwApi_DllName = "shlwapi.dll";
 
         [DllImport(ShlwApi_DllName)]
+        public static extern IntPtr SHAllocShared(IntPtr hData, uint dwSize, uint dwProcessId);
+
+        [DllImport(ShlwApi_DllName)]
+        public static extern IntPtr SHFreeShared(IntPtr hData, uint dwProcessId);
+
+        [DllImport(ShlwApi_DllName)]
         public static extern IntPtr SHLockShared(IntPtr hData, uint dwProcessId);
 
         [DllImport(ShlwApi_DllName, SetLastError = true)]

--- a/src/ManagedShell.WindowsTray/Delegates.cs
+++ b/src/ManagedShell.WindowsTray/Delegates.cs
@@ -28,9 +28,10 @@ namespace ManagedShell.WindowsTray
     public delegate TrayHostSizeData TrayHostSizeDelegate();
 
     /// <summary>
-    /// Delegate signature for the AppBar autohide callback.
+    /// Delegate signature for SHAppBarMessage callbacks.
     /// </summary>
-    /// <param name="edge">The AppBar edge to check for an autohide bar. Null to check any edge.</param>
-    /// <returns>Window handle to the autohide AppBar.</returns>
-    public delegate IntPtr AutoHideBarDelegate(ABEdge? edge);
+    /// <param name="amd">The AppBar message data received by Shell_TrayWnd.</param>
+    /// <param name="handled">Whether the delegate handled the message.</param>
+    /// <returns>Result if handled.</returns>
+    public delegate IntPtr AppBarMessageDelegate(APPBARMSGDATAV3 amd, ref bool handled);
 }


### PR DESCRIPTION
- Added handling for ABM_QUERYPOS and ABM_SETPOS. These messages use shared memory to allow the shell to adjust the AppBarData and be returned to the caller. Previously we just forwarded these on to Explorer as-is, but it couldn't use the shared memory marked with our PID. Now, we open up the shared memory sent to us, then create new shared memory to send on to Explorer, which it is able to use.
- Removed suspend/resume tray functionality hack, since it is no longer needed due to properly working forwarding.
- Refactored AppBarMessage handling to reside fully within AppBarManager
- Reverted setting Explorer taskbar state to not be async due to inconsistent behavior
- Fixed another 'hard-coded' tray size reference
- Improved some code comments

This set of fixes addresses Windows 7 workspace size issues and some other instances where the old hacks didn't work quite well enough.