### PR TITLE
Restore pinned notify icon by tooltip if UID inconsistent

### DIFF
--- a/src/ManagedShell.WindowsTray/NotificationArea.cs
+++ b/src/ManagedShell.WindowsTray/NotificationArea.cs
@@ -278,6 +278,7 @@ namespace ManagedShell.WindowsTray
                     try
                     {
                         bool exists = false;
+                        bool titleChanged = false;
 
                         // hide icons while we are shell which require UWP support & we have a separate implementation for
                         if (nicData.guidItem == new Guid(VOLUME_GUID) && ((EnvironmentHelper.IsAppRunningAsShell && EnvironmentHelper.IsWindows10OrBetter) || GroupPolicyHelper.HideScaVolume))
@@ -304,7 +305,10 @@ namespace ManagedShell.WindowsTray
                             trayIcon.IsHidden = nicData.dwState == 1;
 
                         if ((NIF.TIP & nicData.uFlags) != 0 && !string.IsNullOrEmpty(nicData.szTip))
+                        {
                             trayIcon.Title = nicData.szTip;
+                            titleChanged = true;
+                        }
 
                         if ((NIF.ICON & nicData.uFlags) != 0)
                         {
@@ -369,6 +373,12 @@ namespace ManagedShell.WindowsTray
                         {
                             if ((NIF.INFO & nicData.uFlags) != 0)
                                 handleBalloonData(nicData, trayIcon);
+
+                            if (titleChanged && trayIcon.GUID == default && !trayIcon.IsPinned)
+                            {
+                                // set properties used for pinning
+                                trayIcon.SetPinValues();
+                            }
 
                             ShellLogger.Debug($"NotificationArea: Modified: {trayIcon.Title}");
                         }

--- a/src/ManagedShell.WindowsTray/NotifyIcon.cs
+++ b/src/ManagedShell.WindowsTray/NotifyIcon.cs
@@ -202,7 +202,7 @@ namespace ManagedShell.WindowsTray
             get
             {
                 if (GUID != default) return GUID.ToString();
-                else return Path + ":" + UID.ToString();
+                else return Path + ":" + UID.ToString() + ":" + Title;
             }
         }
 
@@ -249,7 +249,14 @@ namespace ManagedShell.WindowsTray
                 // already pinned, just moving
                 List<string> icons = _notificationArea.PinnedNotifyIcons.ToList();
                 int insertPos = position;
-                icons.Remove(Identifier);
+
+                for (int i = 0; i < icons.Count; i++)
+                {
+                    if (IsEqualByIdentifier(icons[i]))
+                    {
+                        icons.RemoveAt(i);
+                    }
+                }
 
                 if (PinOrder < position && position > 0)
                 {
@@ -284,7 +291,15 @@ namespace ManagedShell.WindowsTray
             }
 
             List<string> icons = _notificationArea.PinnedNotifyIcons.ToList();
-            icons.Remove(Identifier);
+
+            for (int i = 0; i < icons.Count; i++)
+            {
+                if (IsEqualByIdentifier(icons[i]))
+                {
+                    icons.RemoveAt(i);
+                }
+            }
+
             _notificationArea.PinnedNotifyIcons = icons.ToArray();
 
             _isPinned = false;
@@ -298,8 +313,8 @@ namespace ManagedShell.WindowsTray
         {
             for (int i = 0; i < _notificationArea.PinnedNotifyIcons.Length; i++)
             {
-                string item = _notificationArea.PinnedNotifyIcons[i].ToLower();
-                if (item == GUID.ToString().ToLower() || (GUID == default && item == (Path.ToLower() + ":" + UID.ToString())))
+                string item = _notificationArea.PinnedNotifyIcons[i];
+                if (IsEqualByIdentifier(item))
                 {
                     if (!_isPinned)
                     {
@@ -310,6 +325,41 @@ namespace ManagedShell.WindowsTray
                     break;
                 }
             }
+        }
+
+        public bool IsEqualByIdentifier(string otherIdentifier)
+        {
+            otherIdentifier = otherIdentifier.ToLower();
+
+            if (otherIdentifier == GUID.ToString().ToLower())
+            {
+                return true;
+            }
+
+            if (GUID != default || Path == null)
+            {
+                // Ignore below checks
+                return false;
+            }
+
+            if (otherIdentifier == Path.ToLower() + ":" + UID.ToString())
+            {
+                return true;
+            }
+
+            string[] otherIdentifierArray = otherIdentifier.Split(new[] { ':' }, 4);
+
+            if (otherIdentifierArray.Length < 4 || Title == null)
+            {
+                return false;
+            }
+
+            if (otherIdentifierArray[0] + ":" + otherIdentifierArray[1] == Path.ToLower() && otherIdentifierArray[3] == Title.ToLower())
+            {
+                return true;
+            }
+
+            return false;
         }
         #endregion
 


### PR DESCRIPTION
Helps with buggy programs like FastStone Capture (dremin/RetroBar#261), which use a new UID each launch, so we can't match up with the saved identifier of path+UID. Using tooltip rather than simply relying on path gives us a better chance of not accidentally pinning the wrong icons from apps that use multiple icons.