### PR TITLE
Refactor setting TaskbandHWND prop for ITaskbarList

### DIFF
--- a/src/ManagedShell.Interop/NativeMethods.User32.cs
+++ b/src/ManagedShell.Interop/NativeMethods.User32.cs
@@ -1884,6 +1884,9 @@ namespace ManagedShell.Interop
         [DllImport(User32_DllName, SetLastError = true)]
         public static extern bool SetProp(IntPtr hWnd, string lpString, IntPtr hData);
 
+        [DllImport(User32_DllName, SetLastError = true)]
+        public static extern IntPtr RemoveProp(IntPtr hWnd, string lpString);
+
         public enum TBPFLAG
         {
             TBPF_NOPROGRESS = 0,


### PR DESCRIPTION
Also now removes the prop from the Explorer taskbar if running (and restores after we dispose).