### PR TITLE
Fix notifyicon mouse coords with multiple monitors

### DIFF
--- a/src/ManagedShell.Common/Helpers/MouseHelper.cs
+++ b/src/ManagedShell.Common/Helpers/MouseHelper.cs
@@ -1,10 +1,12 @@
-﻿namespace ManagedShell.Common.Helpers
+﻿using ManagedShell.Interop;
+
+namespace ManagedShell.Common.Helpers
 {
     public static class MouseHelper
     {
         public static uint GetCursorPositionParam()
         {
-            return ((uint)System.Windows.Forms.Cursor.Position.Y << 16) | (uint)System.Windows.Forms.Cursor.Position.X;
+            return (uint)NativeMethods.MakeLParam(System.Windows.Forms.Cursor.Position.X, System.Windows.Forms.Cursor.Position.Y);
         }
     }
 }

--- a/src/ManagedShell.Interop/NativeMethods.cs
+++ b/src/ManagedShell.Interop/NativeMethods.cs
@@ -42,10 +42,14 @@ namespace ManagedShell.Interop
         }
 
         // lo = x; hi = y
-        public static IntPtr MakeLParam(int loWord, int hiWord)
+        public static int MakeLParam(int loWord, int hiWord)
         {
-            int i = ((short)hiWord << 16) | ((short)loWord & 0xffff);
-            return new IntPtr(i);
+            return ((short)hiWord << 16) | ((short)loWord & 0xffff);
+        }
+
+        public static IntPtr MakeLParamIntPtr(int loWord, int hiWord)
+        {
+            return new IntPtr(MakeLParam(loWord, hiWord));
         }
     }
 }

--- a/src/ManagedShell.WindowsTray/NotificationArea.cs
+++ b/src/ManagedShell.WindowsTray/NotificationArea.cs
@@ -246,18 +246,18 @@ namespace ManagedShell.WindowsTray
             if (icon != null)
             {
                 if (dwMessage == 1)
-                    return MakeLParam(icon.Placement.Left, icon.Placement.Top);
+                    return MakeLParamIntPtr(icon.Placement.Left, icon.Placement.Top);
                 else if (dwMessage == 2)
-                    return MakeLParam(icon.Placement.Right, icon.Placement.Bottom);
+                    return MakeLParamIntPtr(icon.Placement.Right, icon.Placement.Bottom);
             }
             else if (guidItem == new Guid(VOLUME_GUID))
             {
                 // If the shell is using sndvol32 as a volume control, it won't have a corresponding
                 // tray icon in Windows 10+, but it still requests the icon location. Provide the tray.
                 if (dwMessage == 1)
-                    return MakeLParam(trayHostSizeData.rc.Left, trayHostSizeData.rc.Top);
+                    return MakeLParamIntPtr(trayHostSizeData.rc.Left, trayHostSizeData.rc.Top);
                 else if (dwMessage == 2)
-                    return MakeLParam(trayHostSizeData.rc.Right, trayHostSizeData.rc.Bottom);
+                    return MakeLParamIntPtr(trayHostSizeData.rc.Right, trayHostSizeData.rc.Bottom);
             }
 
             return IntPtr.Zero;


### PR DESCRIPTION
Casting to unsigned caused havoc when mouse coords were negative (which happens with multiple monitors)