### PR TITLE
Improve full-screen logic

### DIFF
--- a/src/ManagedShell.AppBar/FullScreenHelper.cs
+++ b/src/ManagedShell.AppBar/FullScreenHelper.cs
@@ -47,10 +47,16 @@ namespace ManagedShell.AppBar
                     continue;
                 }
 
-                if (appCurrentState == null || app.screen.DeviceName != appCurrentState.screen.DeviceName)
+                if (appCurrentState != null && app.hWnd != hWnd && 
+                    app.screen.DeviceName == appCurrentState.screen.DeviceName &&
+                    Screen.FromHandle(hWnd).DeviceName != appCurrentState.screen.DeviceName)
                 {
-                    removeApps.Add(app);
+                    // if the full-screen window is no longer foreground, keep it
+                    // as long as the foreground window is on a different screen.
+                    continue;
                 }
+
+                removeApps.Add(app);
             }
 
             // remove any changed windows we found


### PR DESCRIPTION
Currently, FullScreenHelper will only remove a full-screen window from the full-screen windows list if it is no longer full-screen or if it has moved to another monitor. This means that a window obstructing it does not remove it from the full-screen list.

This changes the logic to instead only keep a window in the full-screen windows list in two scenarios:
- If it is foreground, full-screen, and hasn't moved to another monitor
- If it is still full-screen, no longer in the foreground, but the new foreground window is on another monitor

Effectively this means that full-screen windows will stay in the full-screen list unless they are obstructed, which is the desired behavior.

This should fix cairoshell/cairoshell#495 and dremin/RetroBar#171.