### PR TITLE
Use CsWinRT embedded instead of TFM to reduce size

### DIFF
--- a/src/ManagedShell.AppBar/ManagedShell.AppBar.csproj
+++ b/src/ManagedShell.AppBar/ManagedShell.AppBar.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net471;net6.0-windows10.0.19041.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net471;net6.0-windows</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>

--- a/src/ManagedShell.Common/ManagedShell.Common.csproj
+++ b/src/ManagedShell.Common/ManagedShell.Common.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net471;net6.0-windows10.0.19041.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net471;net6.0-windows</TargetFrameworks>
     <UseWindowsForms>true</UseWindowsForms>
     <UseWPF>true</UseWPF>
   </PropertyGroup>

--- a/src/ManagedShell.Interop/ManagedShell.Interop.csproj
+++ b/src/ManagedShell.Interop/ManagedShell.Interop.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net471;net6.0-windows10.0.19041.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net471;net6.0-windows</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ManagedShell.ShellFolders/ManagedShell.ShellFolders.csproj
+++ b/src/ManagedShell.ShellFolders/ManagedShell.ShellFolders.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net471;net6.0-windows10.0.19041.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net471;net6.0-windows</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>

--- a/src/ManagedShell.UWPInterop/ManagedShell.UWPInterop.csproj
+++ b/src/ManagedShell.UWPInterop/ManagedShell.UWPInterop.csproj
@@ -1,12 +1,19 @@
-<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net471;net6.0-windows10.0.19041.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net471;net6.0-windows</TargetFrameworks>
     <UseWPF>True</UseWPF>
   </PropertyGroup>
 
+	<PropertyGroup>
+		<LangVersion>9</LangVersion>
+		<CsWinRTEmbedded>true</CsWinRTEmbedded>
+		<CsWinRTWindowsMetadata>10.0.19041.0</CsWinRTWindowsMetadata>
+	</PropertyGroup>
+	
   <ItemGroup>
-    <PackageReference Condition="'$(TargetFramework)' != 'net6.0-windows10.0.19041.0'" Include="Microsoft.Windows.SDK.Contracts" Version="10.0.19041.1" />
+	<PackageReference Condition="'$(TargetFramework)' == 'net6.0-windows'" Include="Microsoft.Windows.CsWinRT" Version="1.6.4" />
+    <PackageReference Condition="'$(TargetFramework)' != 'net6.0-windows'" Include="Microsoft.Windows.SDK.Contracts" Version="10.0.19041.1" />
     <PackageReference Include="System.Security.Principal.Windows" Version="5.0.0" />
   </ItemGroup>
 
@@ -14,5 +21,35 @@
     <ProjectReference Include="..\ManagedShell.Common\ManagedShell.Common.csproj" />
     <ProjectReference Include="..\ManagedShell.ShellFolders\ManagedShell.ShellFolders.csproj" />
   </ItemGroup>
+
+	<PropertyGroup>
+		<CsWinRTIncludes>
+			Windows.ApplicationModel.AddResourcePackageOptions;
+			Windows.ApplicationModel.AppDisplayInfo;
+			Windows.ApplicationModel.AppInstallerInfo;
+			Windows.ApplicationModel.Core.AppDisplayInfo;
+			Windows.ApplicationModel.Core.AppListEntry;
+			Windows.ApplicationModel.Core.IAppListEntry;
+			Windows.ApplicationModel.IAppDisplayInfo;
+			Windows.ApplicationModel.IAppInstallerInfo;
+			Windows.ApplicationModel.IPackage;
+			Windows.ApplicationModel.IPackageCatalog;
+			Windows.ApplicationModel.Package;
+			Windows.Data.Text.TextSegment;
+			Windows.Devices.Geolocation;
+			Windows.Foundation;
+			Windows.Globalization.DayOfWeek;
+			Windows.Management.Deployment;
+			Windows.Storage;
+			Windows.System.IUser;
+			Windows.System.ProcessorArchitecture;
+			Windows.System.User;
+		</CsWinRTIncludes>
+		<CsWinRTExcludes>
+			Windows.Foundation.Diagnostics;
+			Windows.Foundation.PropertyType;
+			Windows.Storage.BulkAccess;
+		</CsWinRTExcludes>
+	</PropertyGroup>
 
 </Project>

--- a/src/ManagedShell.WindowsTasks/ManagedShell.WindowsTasks.csproj
+++ b/src/ManagedShell.WindowsTasks/ManagedShell.WindowsTasks.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net471;net6.0-windows10.0.19041.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net471;net6.0-windows</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>

--- a/src/ManagedShell.WindowsTray/ManagedShell.WindowsTray.csproj
+++ b/src/ManagedShell.WindowsTray/ManagedShell.WindowsTray.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net471;net6.0-windows10.0.19041.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net471;net6.0-windows</TargetFrameworks>
     <UseWPF>true</UseWPF>
   </PropertyGroup>
 

--- a/src/ManagedShell/ManagedShell.csproj
+++ b/src/ManagedShell/ManagedShell.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net471;net6.0-windows10.0.19041.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net471;net6.0-windows</TargetFrameworks>
 	<RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <UseWPF>true</UseWPF>
     <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);CopyProjectReferencesToPackage</TargetsForTfmSpecificBuildOutput>


### PR DESCRIPTION
Fixes shell apps targeting .NET 6 being 25 MB larger than with other targets.