### PR TITLE
Bring correct window to foreground

### DIFF
--- a/src/ManagedShell.Interop/NativeMethods.User32.cs
+++ b/src/ManagedShell.Interop/NativeMethods.User32.cs
@@ -316,6 +316,9 @@ namespace ManagedShell.Interop
         public static extern bool SetForegroundWindow(IntPtr hWnd);
 
         [DllImport(User32_DllName)]
+        public static extern IntPtr GetLastActivePopup(IntPtr hWnd);
+
+        [DllImport(User32_DllName)]
         public static extern IntPtr GetParent(IntPtr handle);
 
         public struct WINDOWPLACEMENT

--- a/src/ManagedShell.WindowsTasks/ApplicationWindow.cs
+++ b/src/ManagedShell.WindowsTasks/ApplicationWindow.cs
@@ -566,7 +566,7 @@ namespace ManagedShell.WindowsTasks
             else
             {
                 NativeMethods.ShowWindow(Handle, NativeMethods.WindowShowStyle.Show);
-                NativeMethods.SetForegroundWindow(Handle);
+                makeForeground();
 
                 if (State == WindowState.Flashing) State = WindowState.Active; // some stubborn windows (Outlook) start flashing while already active, this lets us stop
             }
@@ -586,7 +586,7 @@ namespace ManagedShell.WindowsTasks
             IntPtr retval = IntPtr.Zero;
             NativeMethods.SendMessageTimeout(Handle, (int)NativeMethods.WM.SYSCOMMAND, NativeMethods.SC_RESTORE, 0, 2, 200, ref retval);
 
-            NativeMethods.SetForegroundWindow(Handle);
+            makeForeground();
         }
 
         public void Maximize()
@@ -598,7 +598,12 @@ namespace ManagedShell.WindowsTasks
                 IntPtr retval = IntPtr.Zero;
                 NativeMethods.SendMessageTimeout(Handle, (int)NativeMethods.WM.SYSCOMMAND, NativeMethods.SC_RESTORE, 0, 2, 200, ref retval);
             }
-            NativeMethods.SetForegroundWindow(Handle);
+            makeForeground();
+        }
+
+        private void makeForeground()
+        {
+            NativeMethods.SetForegroundWindow(NativeMethods.GetLastActivePopup(Handle));
         }
 
         internal IntPtr DoClose()


### PR DESCRIPTION
If a window owns a popup and it was the most recently activated, bring it to the foreground. This matches Windows behavior tested back to Windows 2000.

Fixes dremin/RetroBar#353