### PR TITLE
Adds ShellLinkHelper for some common link ops

### DIFF
--- a/src/ManagedShell.ShellFolders/Enums/SLGP_FLAGS.cs
+++ b/src/ManagedShell.ShellFolders/Enums/SLGP_FLAGS.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace ManagedShell.ShellFolders.Enums
+{
+    /// <summary>IShellLink.GetPath fFlags: Flags that specify the type of path information to retrieve</summary>
+    [Flags]
+    public enum SLGP_FLAGS
+    {
+        /// <summary>Retrieves the standard short (8.3 format) file name</summary>
+        SLGP_SHORTPATH = 0x1,
+        /// <summary>Retrieves the Universal Naming Convention (UNC) path name of the file</summary>
+        SLGP_UNCPRIORITY = 0x2,
+        /// <summary>Retrieves the raw path name. A raw path is something that might not exist and may include environment variables that need to be expanded</summary>
+        SLGP_RAWPATH = 0x4
+    }
+}

--- a/src/ManagedShell.ShellFolders/Enums/SLR_FLAGS.cs
+++ b/src/ManagedShell.ShellFolders/Enums/SLR_FLAGS.cs
@@ -1,0 +1,38 @@
+﻿using System;
+
+namespace ManagedShell.ShellFolders.Enums
+{
+    [Flags]
+    public enum SLR_FLAGS
+    {
+        /// <summary>
+        /// Do not display a dialog box if the link cannot be resolved. When SLR_NO_UI is set,
+        /// the high-order word of fFlags can be set to a time-out value that specifies the
+        /// maximum amount of time to be spent resolving the link. The function returns if the
+        /// link cannot be resolved within the time-out duration. If the high-order word is set
+        /// to zero, the time-out duration will be set to the default value of 3,000 milliseconds
+        /// (3 seconds). To specify a value, set the high word of fFlags to the desired time-out
+        /// duration, in milliseconds.
+        /// </summary>
+        SLR_NO_UI = 0x1,
+        /// <summary>Obsolete and no longer used</summary>
+        SLR_ANY_MATCH = 0x2,
+        /// <summary>If the link object has changed, update its path and list of identifiers.
+        /// If SLR_UPDATE is set, you do not need to call IPersistFile::IsDirty to determine
+        /// whether or not the link object has changed.</summary>
+        SLR_UPDATE = 0x4,
+        /// <summary>Do not update the link information</summary>
+        SLR_NOUPDATE = 0x8,
+        /// <summary>Do not execute the search heuristics</summary>
+        SLR_NOSEARCH = 0x10,
+        /// <summary>Do not use distributed link tracking</summary>
+        SLR_NOTRACK = 0x20,
+        /// <summary>Disable distributed link tracking. By default, distributed link tracking tracks
+        /// removable media across multiple devices based on the volume name. It also uses the
+        /// Universal Naming Convention (UNC) path to track remote file systems whose drive letter
+        /// has changed. Setting SLR_NOLINKINFO disables both types of tracking.</summary>
+        SLR_NOLINKINFO = 0x40,
+        /// <summary>Call the Microsoft Windows Installer</summary>
+        SLR_INVOKE_MSI = 0x80
+    }
+}

--- a/src/ManagedShell.ShellFolders/Enums/STGM.cs
+++ b/src/ManagedShell.ShellFolders/Enums/STGM.cs
@@ -1,0 +1,27 @@
+﻿using System;
+
+namespace ManagedShell.ShellFolders.Enums
+{
+    [Flags]
+    public enum STGM
+    {
+        READ = 0x0,
+        WRITE = 0x1,
+        READWRITE = 0x2,
+        SHARE_DENY_NONE = 0x40,
+        SHARE_DENY_READ = 0x30,
+        SHARE_DENY_WRITE = 0x20,
+        SHARE_EXCLUSIVE = 0x10,
+        PRIORITY = 0x40000,
+        CREATE = 0x1000,
+        CONVERT = 0x20000,
+        FAILIFTHERE = 0x0,
+        DIRECT = 0x0,
+        TRANSACTED = 0x10000,
+        NOSCRATCH = 0x100000,
+        NOSNAPSHOT = 0x200000,
+        SIMPLE = 0x8000000,
+        DIRECT_SWMR = 0x400000,
+        DELETEONRELEASE = 0x4000000
+    }
+}

--- a/src/ManagedShell.ShellFolders/Interfaces/IShellLink.cs
+++ b/src/ManagedShell.ShellFolders/Interfaces/IShellLink.cs
@@ -1,0 +1,52 @@
+﻿using ManagedShell.ShellFolders.Enums;
+using ManagedShell.ShellFolders.Structs;
+using System;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace ManagedShell.ShellFolders.Interfaces
+{
+    [ComImport]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    [Guid("000214F9-0000-0000-C000-000000000046")]
+    public interface IShellLink
+    {
+        /// <summary>Retrieves the path and file name of a Shell link object</summary>
+        void GetPath([Out(), MarshalAs(UnmanagedType.LPWStr)] StringBuilder pszFile, int cchMaxPath, out WIN32_FIND_DATA pfd, SLGP_FLAGS fFlags);
+        /// <summary>Retrieves the list of item identifiers for a Shell link object</summary>
+        void GetIDList(out IntPtr ppidl);
+        /// <summary>Sets the pointer to an item identifier list (PIDL) for a Shell link object.</summary>
+        void SetIDList(IntPtr pidl);
+        /// <summary>Retrieves the description string for a Shell link object</summary>
+        void GetDescription([Out(), MarshalAs(UnmanagedType.LPWStr)] StringBuilder pszName, int cchMaxName);
+        /// <summary>Sets the description for a Shell link object. The description can be any application-defined string</summary>
+        void SetDescription([MarshalAs(UnmanagedType.LPWStr)] string pszName);
+        /// <summary>Retrieves the name of the working directory for a Shell link object</summary>
+        void GetWorkingDirectory([Out(), MarshalAs(UnmanagedType.LPWStr)] StringBuilder pszDir, int cchMaxPath);
+        /// <summary>Sets the name of the working directory for a Shell link object</summary>
+        void SetWorkingDirectory([MarshalAs(UnmanagedType.LPWStr)] string pszDir);
+        /// <summary>Retrieves the command-line arguments associated with a Shell link object</summary>
+        void GetArguments([Out(), MarshalAs(UnmanagedType.LPWStr)] StringBuilder pszArgs, int cchMaxPath);
+        /// <summary>Sets the command-line arguments for a Shell link object</summary>
+        void SetArguments([MarshalAs(UnmanagedType.LPWStr)] string pszArgs);
+        /// <summary>Retrieves the hot key for a Shell link object</summary>
+        void GetHotkey(out short pwHotkey);
+        /// <summary>Sets a hot key for a Shell link object</summary>
+        void SetHotkey(short wHotkey);
+        /// <summary>Retrieves the show command for a Shell link object</summary>
+        void GetShowCmd(out int piShowCmd);
+        /// <summary>Sets the show command for a Shell link object. The show command sets the initial show state of the window.</summary>
+        void SetShowCmd(int iShowCmd);
+        /// <summary>Retrieves the location (path and index) of the icon for a Shell link object</summary>
+        void GetIconLocation([Out(), MarshalAs(UnmanagedType.LPWStr)] StringBuilder pszIconPath,
+            int cchIconPath, out int piIcon);
+        /// <summary>Sets the location (path and index) of the icon for a Shell link object</summary>
+        void SetIconLocation([MarshalAs(UnmanagedType.LPWStr)] string pszIconPath, int iIcon);
+        /// <summary>Sets the relative path to the Shell link object</summary>
+        void SetRelativePath([MarshalAs(UnmanagedType.LPWStr)] string pszPathRel, int dwReserved);
+        /// <summary>Attempts to find the target of a Shell link, even if it has been moved or renamed</summary>
+        void Resolve(IntPtr hwnd, SLR_FLAGS fFlags);
+        /// <summary>Sets the path and file name of a Shell link object</summary>
+        void SetPath([MarshalAs(UnmanagedType.LPWStr)] string pszFile);
+    }
+}

--- a/src/ManagedShell.ShellFolders/ShellLink.cs
+++ b/src/ManagedShell.ShellFolders/ShellLink.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace ManagedShell.ShellFolders
+{
+    [ComImport(), Guid("00021401-0000-0000-C000-000000000046")]
+    public class ShellLink
+    {
+    }
+}

--- a/src/ManagedShell.ShellFolders/ShellLinkHelper.cs
+++ b/src/ManagedShell.ShellFolders/ShellLinkHelper.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.ComTypes;
 using ManagedShell.Common.Logging;
 using ManagedShell.ShellFolders.Enums;
@@ -41,6 +42,8 @@ namespace ManagedShell.ShellFolders
             {
                 ShellLogger.Error($"ShellLinkHelper: Unable to create link from {linkTargetPath} to {destinationPath}", e);
             }
+
+            Marshal.FinalReleaseComObject(link);
         }
 
         public static IShellLink Load(IntPtr userInputHwnd, string existingLinkPath)

--- a/src/ManagedShell.ShellFolders/ShellLinkHelper.cs
+++ b/src/ManagedShell.ShellFolders/ShellLinkHelper.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Runtime.InteropServices.ComTypes;
+using ManagedShell.Common.Logging;
+using ManagedShell.ShellFolders.Enums;
+using ManagedShell.ShellFolders.Interfaces;
+
+namespace ManagedShell.ShellFolders
+{
+    public static class ShellLinkHelper
+    {
+        public static void Save(IShellLink existingLink)
+        {
+            ((IPersistFile)existingLink).Save(null, true);
+        }
+
+        public static void Save(IShellLink link, string destinationPath)
+        {
+            ((IPersistFile)link).Save(destinationPath, true);
+        }
+
+        public static IShellLink Create()
+        {
+            ShellLink link = new ShellLink();
+            IShellLink shellLink = (IShellLink)link;
+
+            return shellLink;
+        }
+
+        public static void CreateAndSave(string linkTargetPath, string destinationPath)
+        {
+            ShellLink link = new ShellLink();
+            IShellLink shellLink = (IShellLink)link;
+
+            try
+            {
+                shellLink.SetPath(linkTargetPath);
+
+                Save(shellLink, destinationPath);
+            }
+            catch (Exception e)
+            {
+                ShellLogger.Error($"ShellLinkHelper: Unable to create link from {linkTargetPath} to {destinationPath}", e);
+            }
+        }
+
+        public static IShellLink Load(IntPtr userInputHwnd, string existingLinkPath)
+        {
+            ShellLink link = new ShellLink();
+            IShellLink shellLink = (IShellLink)link;
+            IPersistFile persistFile = (IPersistFile)link;
+
+            try
+            {
+                // load from disk
+                persistFile.Load(existingLinkPath, (int)STGM.READ);
+
+                // attempt to resolve a broken shortcut
+                shellLink.Resolve(userInputHwnd, 0);
+            }
+            catch (Exception e)
+            {
+                ShellLogger.Error($"ShellLinkHelper: Unable to load link from path {existingLinkPath}", e);
+            }
+
+            return shellLink;
+        }
+    }
+}

--- a/src/ManagedShell.ShellFolders/Structs/WIN32_FIND_DATA.cs
+++ b/src/ManagedShell.ShellFolders/Structs/WIN32_FIND_DATA.cs
@@ -1,0 +1,24 @@
+﻿using System.Runtime.InteropServices;
+
+namespace ManagedShell.ShellFolders.Structs
+{
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
+    public struct WIN32_FIND_DATA
+    {
+        public uint dwFileAttributes;
+        public System.Runtime.InteropServices.ComTypes.FILETIME ftCreationTime;
+        public System.Runtime.InteropServices.ComTypes.FILETIME ftLastAccessTime;
+        public System.Runtime.InteropServices.ComTypes.FILETIME ftLastWriteTime;
+        public uint nFileSizeHigh;
+        public uint nFileSizeLow;
+        public uint dwReserved0;
+        public uint dwReserved1;
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 260)]
+        public string cFileName;
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 14)]
+        public string cAlternateFileName;
+        public uint dwFileType;
+        public uint dwCreatorType;
+        public uint wFinderFlags;
+    }
+}


### PR DESCRIPTION
Also adds the necessary interface definitions.

In the future we could create a nice link class that encapsulates link operations, but [IShellLink API](https://docs.microsoft.com/en-us/windows/win32/api/shobjidl_core/nn-shobjidl_core-ishelllinkw) is already fairly straightforward. The helper provides easy access to this, which I think should be good for now.