### PR TITLE
Add more tray guids, remove dark mode build limit

### DIFF
--- a/src/ManagedShell.Common/Helpers/EnvironmentHelper.cs
+++ b/src/ManagedShell.Common/Helpers/EnvironmentHelper.cs
@@ -123,8 +123,7 @@ namespace ManagedShell.Common.Helpers
                     getOSVersion();
                 }
 
-                // This has an upper-bound due to the volatility of the undocumented dark mode API
-                return (osVersionMajor >= 10 && osVersionBuild >= 18362 && osVersionBuild <= 22000);
+                return (osVersionMajor >= 10 && osVersionBuild >= 18362);
             }
         }
 

--- a/src/ManagedShell.WindowsTray/NotificationArea.cs
+++ b/src/ManagedShell.WindowsTray/NotificationArea.cs
@@ -14,6 +14,10 @@ namespace ManagedShell.WindowsTray
 {
     public class NotificationArea : DependencyObject, IDisposable
     {
+        public const string HARDWARE_GUID = "7820ae78-23e3-4229-82c1-e41cb67d5b9c";
+        public const string UPDATE_GUID = "7820ae81-23e3-4229-82c1-e41cb67d5b9c";
+        public const string MICROPHONE_GUID = "7820ae82-23e3-4229-82c1-e41cb67d5b9c";
+        public const string LOCATION_GUID = "7820ae77-23e3-4229-82c1-e41cb67d5b9c";
         public const string HEALTH_GUID = "7820ae76-23e3-4229-82c1-e41cb67d5b9c";
         public const string MEETNOW_GUID = "7820ae83-23e3-4229-82c1-e41cb67d5b9c";
         public const string NETWORK_GUID = "7820ae74-23e3-4229-82c1-e41cb67d5b9c";


### PR DESCRIPTION
The dark mode APIs we're using haven't changed, so we can probably count on them staying around.