### PR TITLE
Track hMonitor by window for multi-mon taskbars

### DIFF
--- a/src/ManagedShell.AppBar/AppBarScreen.cs
+++ b/src/ManagedShell.AppBar/AppBarScreen.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using ManagedShell.Interop;
+using System;
+using System.Collections.Generic;
 using System.Drawing;
 using System.Windows.Forms;
 
@@ -14,14 +16,18 @@ namespace ManagedShell.AppBar
         
         public Rectangle WorkingArea { get; set; }
 
+        public IntPtr HMonitor { get; set; }
+
         public static AppBarScreen FromScreen(Screen screen)
         {
+            IntPtr hMonitor = NativeMethods.MonitorFromPoint(new Point(screen.Bounds.X, screen.Bounds.Y), NativeMethods.MONITOR_DEFAULTTONEAREST);
             return new AppBarScreen
             {
                 Bounds = screen.Bounds,
                 DeviceName = screen.DeviceName,
                 Primary = screen.Primary,
-                WorkingArea = screen.WorkingArea
+                WorkingArea = screen.WorkingArea,
+                HMonitor = hMonitor
             };
         }
 

--- a/src/ManagedShell.Interop/NativeMethods.User32.cs
+++ b/src/ManagedShell.Interop/NativeMethods.User32.cs
@@ -1909,6 +1909,7 @@ namespace ManagedShell.Interop
         public static int WINEVENT_OUTOFCONTEXT = 0;
         public static int WINEVENT_SKIPOWNPROCESS = 2;
         public static int EVENT_OBJECT_UNCLOAKED = 0x8018;
+        public static int EVENT_OBJECT_LOCATIONCHANGE = 0x800B;
 
         public delegate void WinEventProc(IntPtr hWinEventHook, uint eventType, IntPtr hwnd, int idObject, int idChild, uint dwEventThread, uint dwmsEventTime);
 
@@ -3706,5 +3707,15 @@ namespace ManagedShell.Interop
             ///</summary>
             OEM_CLEAR = 0xFE
         }
+
+        public const int MONITOR_DEFAULTTONULL = 0x00000000;
+        public const int MONITOR_DEFAULTTOPRIMARY = 0x00000001;
+        public const int MONITOR_DEFAULTTONEAREST = 0x00000002;
+
+        [DllImport(User32_DllName)]
+        public static extern IntPtr MonitorFromPoint(Point pt, int dwFlags);
+
+        [DllImport(User32_DllName)]
+        public static extern IntPtr MonitorFromWindow(IntPtr hWnd, int dwFlags);
     }
 }

--- a/src/ManagedShell.WindowsTasks/ApplicationWindow.cs
+++ b/src/ManagedShell.WindowsTasks/ApplicationWindow.cs
@@ -258,6 +258,30 @@ namespace ManagedShell.WindowsTasks
             }
         }
 
+        private IntPtr _hMonitor;
+
+        public IntPtr HMonitor
+        {
+            get
+            {
+                if (_hMonitor == IntPtr.Zero)
+                {
+                    SetMonitor();
+                }
+
+                return _hMonitor;
+            }
+
+            private set
+            {
+                if (_hMonitor != value)
+                {
+                    _hMonitor = value;
+                    OnPropertyChanged("HMonitor");
+                }
+            }
+        }
+
         public bool IsMinimized
         {
             get { return NativeMethods.IsIconic(Handle); }
@@ -501,6 +525,11 @@ namespace ManagedShell.WindowsTasks
                     _iconLoading = false;
                 }, CancellationToken.None, TaskCreationOptions.None, IconHelper.IconScheduler);
             }
+        }
+
+        internal void SetMonitor()
+        {
+            HMonitor = NativeMethods.MonitorFromWindow(Handle, NativeMethods.MONITOR_DEFAULTTONEAREST);
         }
 
         public void SetOverlayIcon(IntPtr hIcon)

--- a/src/ManagedShell.WindowsTasks/Tasks.cs
+++ b/src/ManagedShell.WindowsTasks/Tasks.cs
@@ -30,18 +30,18 @@ namespace ManagedShell.WindowsTasks
             }
         }
 
-        public void Initialize(ITaskCategoryProvider taskCategoryProvider)
+        public void Initialize(ITaskCategoryProvider taskCategoryProvider, bool withMultiMonTracking = false)
         {
             if (!_tasksService.IsInitialized)
             {
                 SetTaskCategoryProvider(taskCategoryProvider);
-                Initialize();
+                Initialize(withMultiMonTracking);
             }
         }
 
-        public void Initialize()
+        public void Initialize(bool withMultiMonTracking = false)
         {
-            _tasksService.Initialize();
+            _tasksService.Initialize(withMultiMonTracking);
         }
 
         public void SetTaskCategoryProvider(ITaskCategoryProvider taskCategoryProvider)

--- a/src/ManagedShell.WindowsTasks/TasksService.cs
+++ b/src/ManagedShell.WindowsTasks/TasksService.cs
@@ -29,6 +29,8 @@ namespace ManagedShell.WindowsTasks
         private static int TASKBARBUTTONCREATEDMESSAGE = -1;
         private static IntPtr uncloakEventHook = IntPtr.Zero;
         private WinEventProc uncloakEventProc;
+        private static IntPtr moveEventHook = IntPtr.Zero;
+        private WinEventProc moveEventProc;
 
         internal ITaskCategoryProvider TaskCategoryProvider;
         private TaskCategoryChangeDelegate CategoryChangeDelegate;
@@ -114,6 +116,21 @@ namespace ManagedShell.WindowsTasks
                     }
                 }
 
+                // set event hook for move events
+                moveEventProc = MoveEventCallback;
+
+                if (moveEventHook == IntPtr.Zero)
+                {
+                    moveEventHook = SetWinEventHook(
+                        EVENT_OBJECT_LOCATIONCHANGE,
+                        EVENT_OBJECT_LOCATIONCHANGE,
+                        IntPtr.Zero,
+                        moveEventProc,
+                        0,
+                        0,
+                        WINEVENT_OUTOFCONTEXT);
+                }
+
                 // set window for ITaskbarList
                 setTaskbarListHwnd(_HookWin.Handle);
 
@@ -175,6 +192,7 @@ namespace ManagedShell.WindowsTasks
                 ShellLogger.Debug("TasksService: Deregistering hooks");
                 DeregisterShellHookWindow(_HookWin.Handle);
                 if (uncloakEventHook != IntPtr.Zero) UnhookWinEvent(uncloakEventHook);
+                if (moveEventHook != IntPtr.Zero) UnhookWinEvent(moveEventHook);
                 _HookWin.DestroyHandle();
                 setTaskbarListHwnd(IntPtr.Zero);
             }
@@ -566,6 +584,18 @@ namespace ManagedShell.WindowsTasks
             }
 
             msg.Result = DefWindowProc(msg.HWnd, msg.Msg, msg.WParam, msg.LParam);
+        }
+
+        private void MoveEventCallback(IntPtr hWinEventHook, uint eventType, IntPtr hWnd, int idObject, int idChild, uint dwEventThread, uint dwmsEventTime)
+        {
+            if (hWnd != IntPtr.Zero && idObject == 0 && idChild == 0)
+            {
+                if (Windows.Any(i => i.Handle == hWnd))
+                {
+                    ApplicationWindow win = Windows.First(wnd => wnd.Handle == hWnd);
+                    win.SetMonitor();
+                }
+            }
         }
 
         private void UncloakEventCallback(IntPtr hWinEventHook, uint eventType, IntPtr hWnd, int idObject, int idChild, uint dwEventThread, uint dwmsEventTime)

--- a/src/ManagedShell.WindowsTasks/TasksService.cs
+++ b/src/ManagedShell.WindowsTasks/TasksService.cs
@@ -73,7 +73,7 @@ namespace ManagedShell.WindowsTasks
             TaskIconSize = iconSize;
         }
 
-        internal void Initialize()
+        internal void Initialize(bool withMultiMonTracking)
         {
             if (IsInitialized)
             {
@@ -116,19 +116,22 @@ namespace ManagedShell.WindowsTasks
                     }
                 }
 
-                // set event hook for move events
-                moveEventProc = MoveEventCallback;
-
-                if (moveEventHook == IntPtr.Zero)
+                if (withMultiMonTracking)
                 {
-                    moveEventHook = SetWinEventHook(
-                        EVENT_OBJECT_LOCATIONCHANGE,
-                        EVENT_OBJECT_LOCATIONCHANGE,
-                        IntPtr.Zero,
-                        moveEventProc,
-                        0,
-                        0,
-                        WINEVENT_OUTOFCONTEXT);
+                    // set event hook for move events
+                    moveEventProc = MoveEventCallback;
+
+                    if (moveEventHook == IntPtr.Zero)
+                    {
+                        moveEventHook = SetWinEventHook(
+                            EVENT_OBJECT_LOCATIONCHANGE,
+                            EVENT_OBJECT_LOCATIONCHANGE,
+                            IntPtr.Zero,
+                            moveEventProc,
+                            0,
+                            0,
+                            WINEVENT_OUTOFCONTEXT);
+                    }
                 }
 
                 // set window for ITaskbarList

--- a/src/ManagedShell/ShellManager.cs
+++ b/src/ManagedShell/ShellManager.cs
@@ -56,7 +56,7 @@ namespace ManagedShell
 
             if (config.EnableTasksService && config.AutoStartTasksService)
             {
-                Tasks.Initialize();
+                Tasks.Initialize(true);
             }
         }
 


### PR DESCRIPTION
This is to be used with cairoshell/cairoshell#203.

The event for window LocationChange seems to fire constantly while a window moves. I tried MoveSizeEnd instead, but it is not exhaustive enough. I'm not seeing any performance issues with LocationChange however. If you're aware of a better way to track this, I'm all ears! I added a parameter to toggle this functionality in case the shell doesn't care.