### PR TITLE
ShellConfig option for multi-mon, handle more ABMs

### DIFF
--- a/src/ManagedShell.AppBar/AppBarManager.cs
+++ b/src/ManagedShell.AppBar/AppBarManager.cs
@@ -56,6 +56,10 @@ namespace ManagedShell.AppBar
                     return appBarMessage_GetState(amd, ref handled);
                 case ABMsg.ABM_GETAUTOHIDEBAR:
                     return appBarMessage_GetAutoHideBar(amd, ref handled);
+                case ABMsg.ABM_ACTIVATE:
+                case ABMsg.ABM_WINDOWPOSCHANGED:
+                    handled = true;
+                    return (IntPtr)1;
             }
             return IntPtr.Zero;
         }

--- a/src/ManagedShell/ShellConfig.cs
+++ b/src/ManagedShell/ShellConfig.cs
@@ -22,7 +22,7 @@ namespace ManagedShell
         public bool AutoStartTasksService;
 
         /// <summary>
-        /// Controls whether the tasks service will be multi-mon aware.<br />
+        /// Controls whether the tasks service will be multi-mon aware when using AutoStartTasksService.<br />
         /// This keeps the HMonitor property of each ApplicationWindow updated.<br />
         /// <br />
         /// By default, this is enabled.

--- a/src/ManagedShell/ShellConfig.cs
+++ b/src/ManagedShell/ShellConfig.cs
@@ -22,6 +22,14 @@ namespace ManagedShell
         public bool AutoStartTasksService;
 
         /// <summary>
+        /// Controls whether the tasks service will be multi-mon aware.<br />
+        /// This keeps the HMonitor property of each ApplicationWindow updated.<br />
+        /// <br />
+        /// By default, this is enabled.
+        /// </summary>
+        public bool MultiMonAwareTasksService;
+
+        /// <summary>
         /// This is the icon size that ManagedShell will request from each task.<br />
         /// <br />
         /// By default, the small size is used.

--- a/src/ManagedShell/ShellManager.cs
+++ b/src/ManagedShell/ShellManager.cs
@@ -12,6 +12,7 @@ namespace ManagedShell
         {
             EnableTasksService = true,
             AutoStartTasksService = true,
+            MultiMonAwareTasksService = true,
             TaskIconSize = TasksService.DEFAULT_ICON_SIZE,
             
             EnableTrayService = true,
@@ -56,7 +57,7 @@ namespace ManagedShell
 
             if (config.EnableTasksService && config.AutoStartTasksService)
             {
-                Tasks.Initialize(true);
+                Tasks.Initialize(config.MultiMonAwareTasksService);
             }
         }
 


### PR DESCRIPTION
- ABM_ACTIVATE and ABM_WINDOWPOSCHANGED don't need to be forwarded to Explorer when we are running, so handle them. This fixes some cases of the Explorer taskbar raising when clicking tray icons, causing issues such as dremin/RetroBar#413.
- ShellConfig can now be used to enable or disable multi-mon tasks support.