### PR TITLE
Add events so shells can detect window activation without polling

### DIFF
--- a/src/ManagedShell.WindowsTasks/TasksService.cs
+++ b/src/ManagedShell.WindowsTasks/TasksService.cs
@@ -18,7 +18,10 @@ namespace ManagedShell.WindowsTasks
     public class TasksService : DependencyObject, IDisposable
     {
         public static readonly IconSize DEFAULT_ICON_SIZE = IconSize.Small;
-        
+
+        public event EventHandler<WindowActivatedEventArgs> WindowActivated;
+        public event EventHandler<EventArgs> DesktopActivated;
+
         private NativeWindowEx _HookWin;
         private object _windowsLock = new object();
         internal bool IsInitialized;
@@ -377,7 +380,18 @@ namespace ManagedShell.WindowsTasks
                                             if (wind.WinFileName == win.WinFileName && wind.Handle != win.Handle)
                                                 wind.SetShowInTaskbar();
                                         }
+
+                                        WindowActivatedEventArgs args = new WindowActivatedEventArgs
+                                        {
+                                            Window = win
+                                        };
+
+                                        WindowActivated?.Invoke(this, args);
                                     }
+                                }
+                                else
+                                {
+                                    DesktopActivated?.Invoke(this, new EventArgs());
                                 }
                                 break;
 

--- a/src/ManagedShell.WindowsTasks/WindowActivatedEventArgs.cs
+++ b/src/ManagedShell.WindowsTasks/WindowActivatedEventArgs.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace ManagedShell.WindowsTasks
+{
+    public class WindowActivatedEventArgs : EventArgs
+    {
+        public ApplicationWindow Window;
+    }
+}


### PR DESCRIPTION
There are several use cases for shells to receive an event when any window is activated, regardless of its taskbar visibility. This allows them to do so without polling.

TasksService.WindowActivated is fired whenever any window is activated (excluding the desktop/taskbar), and passes the window in args
TasksService.DesktopActivated is fired whenever the desktop/taskbar is activated only

In the future FullScreenHelper may be able to be refactored to use this instead of polling, when tasks are enabled.