### PR TITLE
Add auto-hide support for AppBars

### DIFF
--- a/src/ManagedShell.AppBar/AppBarMode.cs
+++ b/src/ManagedShell.AppBar/AppBarMode.cs
@@ -1,0 +1,9 @@
+﻿namespace ManagedShell.AppBar
+{
+    public enum AppBarMode : int
+    {
+        Normal = 0,
+        AutoHide,
+        None
+    }
+}

--- a/src/ManagedShell.AppBar/AppBarWindow.cs
+++ b/src/ManagedShell.AppBar/AppBarWindow.cs
@@ -81,10 +81,10 @@ namespace ManagedShell.AppBar
             get => ShouldAllowAutoHide();
         }
         protected internal bool RequiresScreenEdge;
-        protected internal double AutoHideShowMargin = 2;
-        protected internal double AutoHideDelayMs = 400;
-        protected internal double AutoHideAnimationMs = 300;
-        protected internal double AutoHideShowAnimationMs = 150;
+        protected double AutoHideShowMargin = 2;
+        protected double AutoHideDelayMs = 400;
+        protected double AutoHideAnimationMs = 300;
+        protected double AutoHideShowAnimationMs = 150;
 
         private bool _isDragWithin;
         private bool _isMouseWithin;
@@ -551,6 +551,13 @@ namespace ManagedShell.AppBar
             if (EnableBlur != enable && Handle != IntPtr.Zero && AllowsTransparency)
             {
                 EnableBlur = enable;
+
+                if (enable && AppBarMode == AppBarMode.AutoHide && AllowAutoHide)
+                {
+                    // If we're auto-hidden, don't actually enable blur right now.
+                    return;
+                }
+
                 WindowHelper.SetWindowBlur(Handle, enable);
             }
         }

--- a/src/ManagedShell.AppBar/AppBarWindow.cs
+++ b/src/ManagedShell.AppBar/AppBarWindow.cs
@@ -7,6 +7,7 @@ using System.Runtime.CompilerServices;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Interop;
+using System.Windows.Media.Animation;
 using System.Windows.Threading;
 using Application = System.Windows.Application;
 
@@ -49,15 +50,51 @@ namespace ManagedShell.AppBar
                 OnPropertyChanged("Orientation");
             }
         }
-        protected internal bool EnableAppBar = true;
+        private AppBarMode _appBarMode;
+        public AppBarMode AppBarMode
+        {
+            get
+            {
+                return _appBarMode;
+            }
+            set
+            {
+                _appBarMode = value;
+                OnPropertyChanged();
+            }
+        }
+        private FrameworkElement _autoHideElement;
+        public FrameworkElement AutoHideElement
+        {
+            get
+            {
+                return _autoHideElement;
+            }
+            set
+            {
+                _autoHideElement = value;
+                OnPropertyChanged();
+            }
+        }
+        public bool AllowAutoHide
+        {
+            get => ShouldAllowAutoHide();
+        }
         protected internal bool RequiresScreenEdge;
+        protected internal double AutoHideShowMargin = 2;
+        protected internal double AutoHideDelayMs = 400;
+        protected internal double AutoHideAnimationMs = 150;
+
+        private bool _isMouseWithin;
+        private bool _isContextMenuOpen;
+        private DispatcherTimer _peekAutoHideTimer;
 
         public Orientation Orientation
         {
             get => (AppBarEdge == AppBarEdge.Left || AppBarEdge == AppBarEdge.Right) ? Orientation.Vertical : Orientation.Horizontal;
         }
 
-        public AppBarWindow(AppBarManager appBarManager, ExplorerHelper explorerHelper, FullScreenHelper fullScreenHelper, AppBarScreen screen, AppBarEdge edge, double size)
+        public AppBarWindow(AppBarManager appBarManager, ExplorerHelper explorerHelper, FullScreenHelper fullScreenHelper, AppBarScreen screen, AppBarEdge edge, AppBarMode mode, double size)
         {
             _explorerHelper = explorerHelper;
             _fullScreenHelper = fullScreenHelper;
@@ -65,6 +102,12 @@ namespace ManagedShell.AppBar
 
             Closing += OnClosing;
             SourceInitialized += OnSourceInitialized;
+
+            MouseEnter += AppBarWindow_MouseEnter;
+            MouseLeave += AppBarWindow_MouseLeave;
+            ContextMenuOpening += AppBarWindow_ContextMenuOpening;
+            ContextMenuClosing += AppBarWindow_ContextMenuClosing;
+            PropertyChanged += AppBarWindow_PropertyChanged;
 
             ResizeMode = ResizeMode.NoResize;
             ShowInTaskbar = false;
@@ -75,6 +118,7 @@ namespace ManagedShell.AppBar
 
             Screen = screen;
             AppBarEdge = edge;
+            AppBarMode = mode;
 
             if (Orientation == Orientation.Vertical)
             {
@@ -84,6 +128,119 @@ namespace ManagedShell.AppBar
             {
                 DesiredHeight = size;
             }
+        }
+
+        private void AppBarWindow_PropertyChanged(object sender, PropertyChangedEventArgs e)
+        {
+            if (IsOpening)
+            {
+                return;
+            }
+
+            if (e.PropertyName == "AllowAutoHide")
+            {
+                ShellLogger.Debug($"AllowAutoHide: {AllowAutoHide}");
+
+                if (AllowAutoHide)
+                {
+                    AnimateAutoHide(false);
+                }
+                else
+                {
+                    AnimateAutoHide(true);
+                }
+            }
+            else if (e.PropertyName == "AppBarMode")
+            {
+                OnPropertyChanged("AllowAutoHide");
+                if (AppBarMode == AppBarMode.Normal)
+                {
+                    RegisterAppBar();
+                }
+                else
+                {
+                    UnregisterAppBar();
+                }
+
+                if (AppBarMode == AppBarMode.AutoHide)
+                {
+                    _appBarManager.RegisterAutoHideBar(this);
+                }
+                else
+                {
+                    _appBarManager.UnregisterAutoHideBar(this);
+                }
+            }
+        }
+
+        private void AnimateAutoHide(bool isShowing)
+        {
+            if (AutoHideElement == null)
+            {
+                return;
+            }
+
+            if (!isShowing && AppBarMode != AppBarMode.AutoHide)
+            {
+                return;
+            }
+
+            double animTo = 0;
+
+            if (!isShowing)
+            {
+                animTo = Orientation == Orientation.Horizontal ? DesiredHeight : DesiredWidth;
+                animTo -= AutoHideShowMargin;
+
+                if (AppBarEdge == AppBarEdge.Left || AppBarEdge == AppBarEdge.Top)
+                {
+                    animTo *= -1;
+                }
+            }
+
+            var animation = new DoubleAnimation(animTo, TimeSpan.FromMilliseconds(AutoHideAnimationMs).Duration());
+            animation.BeginTime = isShowing ? TimeSpan.Zero : TimeSpan.FromMilliseconds(AutoHideDelayMs);
+
+            Storyboard.SetTarget(animation, AutoHideElement);
+            Storyboard.SetTargetProperty(animation, new PropertyPath($"RenderTransform.(TranslateTransform.{(Orientation == Orientation.Horizontal ? 'Y' : 'X')})"));
+
+            var storyboard = new Storyboard();
+            storyboard.Children.Add(animation);
+
+            animation.CurrentStateInvalidated += (object sender, EventArgs e) => {
+                if (!isShowing && EnableBlur && Handle != IntPtr.Zero && AllowsTransparency && ((AnimationClock)sender).CurrentState == ClockState.Active && AllowAutoHide)
+                {
+                    WindowHelper.SetWindowBlur(Handle, false);
+                }
+            };
+
+            storyboard.Completed += (object sender, EventArgs e) => {
+                if (isShowing && EnableBlur && Handle != IntPtr.Zero && AllowsTransparency && !AllowAutoHide)
+                {
+                    WindowHelper.SetWindowBlur(Handle, true);
+                }
+            };
+
+            storyboard.Begin(AutoHideElement);
+        }
+
+        protected void PeekDuringAutoHide(int msToPeek = 500)
+        {
+            _peekAutoHideTimer?.Stop();
+
+            AnimateAutoHide(true);
+
+            _peekAutoHideTimer = new DispatcherTimer();
+            _peekAutoHideTimer.Interval = TimeSpan.FromMilliseconds(msToPeek);
+            _peekAutoHideTimer.Tick += (object sender, EventArgs e) =>
+            {
+                _peekAutoHideTimer?.Stop();
+                if (AllowAutoHide)
+                {
+                    AnimateAutoHide(false);
+                }
+            };
+            _peekAutoHideTimer.Start();
         }
 
         #region Events
@@ -114,7 +271,14 @@ namespace ManagedShell.AppBar
                 DelaySetPosition();
             }
 
-            RegisterAppBar();
+            if (AppBarMode == AppBarMode.Normal)
+            {
+                RegisterAppBar();
+            }
+            else if (AppBarMode == AppBarMode.AutoHide)
+            {
+                _appBarManager.RegisterAutoHideBar(this);
+            }
 
             // hide from alt-tab etc
             WindowHelper.HideWindowFromTasks(Handle);
@@ -123,6 +287,7 @@ namespace ManagedShell.AppBar
             _fullScreenHelper.FullScreenApps.CollectionChanged += FullScreenApps_CollectionChanged;
 
             IsOpening = false;
+            OnPropertyChanged("AllowAutoHide");
         }
 
         private void OnClosing(object sender, CancelEventArgs e)
@@ -134,6 +299,7 @@ namespace ManagedShell.AppBar
             if (AllowClose)
             {
                 UnregisterAppBar();
+                _appBarManager.UnregisterAutoHideBar(this);
 
                 // unregister full-screen notifications
                 _fullScreenHelper.FullScreenApps.CollectionChanged -= FullScreenApps_CollectionChanged;
@@ -169,6 +335,50 @@ namespace ManagedShell.AppBar
             }
         }
 
+        private void AppBarWindow_ContextMenuClosing(object sender, ContextMenuEventArgs e)
+        {
+            bool currentAutoHide = AllowAutoHide;
+            _isContextMenuOpen = false;
+
+            if (AllowAutoHide != currentAutoHide)
+            {
+                OnPropertyChanged("AllowAutoHide");
+            }
+        }
+
+        private void AppBarWindow_ContextMenuOpening(object sender, ContextMenuEventArgs e)
+        {
+            bool currentAutoHide = AllowAutoHide;
+            _isContextMenuOpen = true;
+
+            if (AllowAutoHide != currentAutoHide)
+            {
+                OnPropertyChanged("AllowAutoHide");
+            }
+        }
+
+        private void AppBarWindow_MouseLeave(object sender, System.Windows.Input.MouseEventArgs e)
+        {
+            bool currentAutoHide = AllowAutoHide;
+            _isMouseWithin = false;
+
+            if (AllowAutoHide != currentAutoHide)
+            {
+                OnPropertyChanged("AllowAutoHide");
+            }
+        }
+
+        private void AppBarWindow_MouseEnter(object sender, System.Windows.Input.MouseEventArgs e)
+        {
+            bool currentAutoHide = AllowAutoHide;
+            _isMouseWithin = true;
+
+            if (AllowAutoHide != currentAutoHide)
+            {
+                OnPropertyChanged("AllowAutoHide");
+            }
+        }
+
         protected virtual IntPtr WndProc(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled)
         {
             if (msg == AppBarMessageId && AppBarMessageId != -1)
@@ -200,7 +410,7 @@ namespace ManagedShell.AppBar
                 }
                 handled = true;
             }
-            else if (msg == (int)NativeMethods.WM.ACTIVATE && EnableAppBar && !EnvironmentHelper.IsAppRunningAsShell && !AllowClose)
+            else if (msg == (int)NativeMethods.WM.ACTIVATE && AppBarMode == AppBarMode.Normal && !EnvironmentHelper.IsAppRunningAsShell && !AllowClose)
             {
                 _appBarManager.AppBarActivate(hwnd);
             }
@@ -218,7 +428,7 @@ namespace ManagedShell.AppBar
                     wndPos.UpdateMessage(lParam);
                 }
             }
-            else if (msg == (int)NativeMethods.WM.WINDOWPOSCHANGED && EnableAppBar && !EnvironmentHelper.IsAppRunningAsShell && !AllowClose)
+            else if (msg == (int)NativeMethods.WM.WINDOWPOSCHANGED && AppBarMode == AppBarMode.Normal && !EnvironmentHelper.IsAppRunningAsShell && !AllowClose)
             {
                 _appBarManager.AppBarWindowPosChanged(hwnd);
             }
@@ -274,11 +484,11 @@ namespace ManagedShell.AppBar
         public void SetScreenPosition()
         {
             // set our position if running as shell, otherwise let AppBar do the work
-            if (EnvironmentHelper.IsAppRunningAsShell || !EnableAppBar)
+            if (EnvironmentHelper.IsAppRunningAsShell || AppBarMode != AppBarMode.Normal)
             {
                 DelaySetPosition();
             }
-            else if (EnableAppBar)
+            else if (AppBarMode == AppBarMode.Normal)
             {
                 if (Orientation == Orientation.Vertical)
                 {
@@ -341,7 +551,7 @@ namespace ManagedShell.AppBar
 
         protected void RegisterAppBar()
         {
-            if (!EnableAppBar || _appBarManager.AppBars.Contains(this))
+            if (AppBarMode != AppBarMode.Normal || _appBarManager.AppBars.Contains(this))
             {
                 return;
             }
@@ -391,13 +601,21 @@ namespace ManagedShell.AppBar
             }
         }
 
+        protected virtual bool ShouldAllowAutoHide()
+        {
+            return AppBarMode == AppBarMode.AutoHide && !_isMouseWithin && !_isContextMenuOpen;
+        }
+
         protected virtual void CustomClosing() { }
 
         protected virtual void SetScreenProperties(ScreenSetupReason reason)
         {
             _fullScreenHelper.NotifyScreensChanged();
 
-            Screen = AppBarScreen.FromPrimaryScreen();
+            if (Screen.Primary && reason != ScreenSetupReason.DpiChange)
+            {
+                Screen = AppBarScreen.FromPrimaryScreen();
+            }
             SetScreenPosition();
         }
 
@@ -451,7 +669,7 @@ namespace ManagedShell.AppBar
 
         #region INotifyPropertyChanged
         public event PropertyChangedEventHandler PropertyChanged;
-        private void OnPropertyChanged([CallerMemberName] string propertyName = "")
+        protected void OnPropertyChanged([CallerMemberName] string propertyName = "")
         {
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }

--- a/src/ManagedShell.Interop/NativeMethods.Shell32.cs
+++ b/src/ManagedShell.Interop/NativeMethods.Shell32.cs
@@ -54,7 +54,8 @@ namespace ManagedShell.Interop
             ABM_GETAUTOHIDEBAR,
             ABM_SETAUTOHIDEBAR,
             ABM_WINDOWPOSCHANGED,
-            ABM_SETSTATE
+            ABM_SETSTATE,
+            ABM_GETAUTOHIDEBAREX
         }
 
         public enum ABEdge : int

--- a/src/ManagedShell.WindowsTasks/TasksService.cs
+++ b/src/ManagedShell.WindowsTasks/TasksService.cs
@@ -597,6 +597,9 @@ namespace ManagedShell.WindowsTasks
                         ShellLogger.Debug("TasksService: ITaskbarList: SetTabProperties HWND:" + msg.WParam);
                         msg.Result = IntPtr.Zero;
                         return;
+                    default:
+                        ShellLogger.Debug($"TasksService: Unknown ITaskbarList Msg: {msg.Msg} LParam: {msg.LParam} WParam: {msg.WParam}");
+                        break;
                 }
             }
 


### PR DESCRIPTION
Cairo has a hacked together implementation of auto-hide. This PR adds support for auto-hide to AppBarWindow and AppBarManager so that any ManagedShell consumer can use auto-hide. It is also extensible so that, for example, shells can prevent auto-hide when attached panels etc are open.

I have ported Cairo to use the new auto-hide mechanism and have also used it to add auto-hide to RetroBar, so it seems to satisfy various use cases.

Also added an infinite-loop protection mechanism to AppBarManager from some unrelated debugging exercises that I thought would be good to keep.