### PR TITLE
AppBar improvements

### DIFF
--- a/src/ManagedShell.AppBar/AppBarManager.cs
+++ b/src/ManagedShell.AppBar/AppBarManager.cs
@@ -404,10 +404,10 @@ namespace ManagedShell.AppBar
                 bool isSameCoords = false;
                 if (!isCreate)
                 {
-                    bool topUnchanged = abd.rc.Top == (abWindow.Top * abWindow.DpiScale);
-                    bool leftUnchanged = abd.rc.Left == (abWindow.Left * abWindow.DpiScale);
-                    bool bottomUnchanged = abd.rc.Bottom == (abWindow.Top * abWindow.DpiScale) + sHeight;
-                    bool rightUnchanged = abd.rc.Right == (abWindow.Left * abWindow.DpiScale) + sWidth;
+                    bool topUnchanged = abd.rc.Top == Math.Round(abWindow.Top * abWindow.DpiScale);
+                    bool leftUnchanged = abd.rc.Left == Math.Round(abWindow.Left * abWindow.DpiScale);
+                    bool bottomUnchanged = abd.rc.Bottom == Math.Round((abWindow.Top * abWindow.DpiScale) + (abWindow.Height * abWindow.DpiScale));
+                    bool rightUnchanged = abd.rc.Right == Math.Round((abWindow.Left * abWindow.DpiScale) + (abWindow.Width * abWindow.DpiScale));
 
                     isSameCoords = topUnchanged
                                    && leftUnchanged
@@ -417,7 +417,7 @@ namespace ManagedShell.AppBar
 
                 if (!isSameCoords)
                 {
-                    ShellLogger.Debug($"AppBarManager: {abWindow.Name} changing position (TxLxBxR) to {abd.rc.Top}x{abd.rc.Left}x{abd.rc.Bottom}x{abd.rc.Right} from {abWindow.Top * abWindow.DpiScale}x{abWindow.Left * abWindow.DpiScale}x{(abWindow.Top * abWindow.DpiScale) + sHeight}x{ (abWindow.Left * abWindow.DpiScale) + sWidth}");
+                    ShellLogger.Debug($"AppBarManager: {abWindow.Name} changing position (TxLxBxR) to {abd.rc.Top}x{abd.rc.Left}x{abd.rc.Bottom}x{abd.rc.Right} from {abWindow.Top * abWindow.DpiScale}x{abWindow.Left * abWindow.DpiScale}x{Math.Round((abWindow.Top * abWindow.DpiScale) + (abWindow.Height * abWindow.DpiScale))}x{Math.Round((abWindow.Left * abWindow.DpiScale) + (abWindow.Width * abWindow.DpiScale))}");
                     abWindow.SetAppBarPosition(abd.rc);
                 }
 


### PR DESCRIPTION
- Use SetWindowPos to resize in single operation
- Fix incorrect comparison logic in ABSetPos
- Add configurable auto-hide show delay

The big change here is coalescing the previous 4 separate size/pos updates (top, left, width, height) into 1 operation via SetWindowPos. This fixes a lot of the raciness I've seen with the positioning logic.