### PR TITLE
Add app activation

### DIFF
--- a/src/ManagedShell.Common/Helpers/ShellHelper.cs
+++ b/src/ManagedShell.Common/Helpers/ShellHelper.cs
@@ -7,6 +7,7 @@ using System.Text;
 using ManagedShell.Common.Logging;
 using static ManagedShell.Interop.NativeMethods;
 using ManagedShell.Common.Enums;
+using ManagedShell.Common.Interfaces;
 
 namespace ManagedShell.Common.Helpers
 {
@@ -49,6 +50,21 @@ namespace ManagedShell.Common.Helpers
             {
                 // No 'Open' command associated with this filetype in the registry
                 ShowOpenWithDialog(proc.StartInfo.FileName);
+                return false;
+            }
+        }
+
+        public static bool ActivateApplication(string appUserModelId, string args = "")
+        {
+            var aam = new ApplicationActivationManager() as IApplicationActivationManager;
+            try
+            {
+                aam.ActivateApplication(appUserModelId, args, ActivateOptions.None);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                ShellLogger.Error($"Error activating application {appUserModelId} with args \"{args}\". ({ex.Message})");
                 return false;
             }
         }

--- a/src/ManagedShell.Common/Interfaces/IApplicationActivationManager.cs
+++ b/src/ManagedShell.Common/Interfaces/IApplicationActivationManager.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) 2019, Microsoft Corporation
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+// SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+// ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+// IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+//
+
+// refer to https://docs.microsoft.com/en-us/windows/desktop/api/shobjidl_core/nn-shobjidl_core-iapplicationactivationmanager for more details regarding IApplicationActivationManager
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace ManagedShell.Common.Interfaces
+{
+    public enum ActivateOptions
+    {
+        None = 0x0,
+        DesignMode = 0x1,
+        NoErrorUi = 0x2,
+        NoSplashScreen = 0x4,
+    };
+
+    [Guid("2e941141-7f97-4756-ba1d-9decde894a3d")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public interface IApplicationActivationManager
+    {
+        int ActivateApplication(
+            [In][MarshalAs(UnmanagedType.LPWStr)] string appUserModelId,
+            [In][MarshalAs(UnmanagedType.LPWStr)] string arguments,
+            [In][MarshalAs(UnmanagedType.U4)] ActivateOptions options);
+    }
+
+    [ComImport]
+    [Guid("45BA127D-10A8-46EA-8AB7-56EA9078943C")]
+    public class ApplicationActivationManager
+    {
+    }
+}

--- a/src/ManagedShell.UWPInterop/StoreApp.cs
+++ b/src/ManagedShell.UWPInterop/StoreApp.cs
@@ -13,6 +13,7 @@ namespace ManagedShell.UWPInterop
         public readonly string AppUserModelId;
         public string DisplayName;
         public string EntryPoint;
+        public string HostId;
         public string IconColor;
 
         public string SmallIconPath;

--- a/src/ManagedShell.UWPInterop/StoreAppHelper.cs
+++ b/src/ManagedShell.UWPInterop/StoreAppHelper.cs
@@ -106,7 +106,8 @@ namespace ManagedShell.UWPInterop
                 ExtraLargeIconPath = icons[IconSize.ExtraLarge],
                 JumboIconPath = icons[IconSize.Jumbo],
                 IconColor = getPlateColor(icons[IconSize.Small], appNode, xmlnsManager),
-                EntryPoint = getEntryPoint(appNode, xmlnsManager)
+                EntryPoint = getEntryPoint(appNode, xmlnsManager),
+                HostId = getHostId(appNode, xmlnsManager)
             };
 
             return storeApp;
@@ -132,6 +133,7 @@ namespace ManagedShell.UWPInterop
             xmlnsManager.AddNamespace("uap3", "http://schemas.microsoft.com/appx/manifest/uap/windows10/3");
             xmlnsManager.AddNamespace("uap4", "http://schemas.microsoft.com/appx/manifest/uap/windows10/4");
             xmlnsManager.AddNamespace("uap5", "http://schemas.microsoft.com/appx/manifest/uap/windows10/5");
+            xmlnsManager.AddNamespace("uap10", "http://schemas.microsoft.com/appx/manifest/uap/windows10/10");
 
             return xmlnsManager;
         }
@@ -143,7 +145,7 @@ namespace ManagedShell.UWPInterop
             if (node == null && nodeText.Contains("uap:"))
             {
                 int i = 0;
-                string[] namespaces = { "uap:", "uap2:", "uap3:", "uap4:", "uap5:" };
+                string[] namespaces = { "uap:", "uap2:", "uap3:", "uap4:", "uap5:", "uap10:" };
                 while (node == null && i <= 3)
                 {
                     nodeText = nodeText.Replace(namespaces[i], namespaces[i + 1]);
@@ -183,6 +185,11 @@ namespace ManagedShell.UWPInterop
         private static string getEntryPoint(XmlNode app, XmlNamespaceManager xmlnsManager)
         {
             return app.SelectSingleNode("@EntryPoint", xmlnsManager)?.Value;
+        }
+
+        private static string getHostId(XmlNode app, XmlNamespaceManager xmlnsManager)
+        {
+            return app.SelectSingleNode("@uap10:HostId", xmlnsManager)?.Value;
         }
 
         private static string getPlateColor(string iconPath, XmlNode app, XmlNamespaceManager xmlnsManager)


### PR DESCRIPTION
Shells can use ShellHelper.ActivateApplication to launch an app via AppUserModelID. This allows launches via AUMID without Explorer running.