### PR TITLE
Don't run peek code if appbar not using autohide

### DIFF
--- a/src/ManagedShell.AppBar/AppBarWindow.cs
+++ b/src/ManagedShell.AppBar/AppBarWindow.cs
@@ -228,6 +228,11 @@ namespace ManagedShell.AppBar
 
         protected void PeekDuringAutoHide(int msToPeek = 500)
         {
+            if (AppBarMode != AppBarMode.AutoHide)
+            {
+                return;
+            }
+
             _peekAutoHideTimer?.Stop();
 
             AnimateAutoHide(false);


### PR DESCRIPTION
This means shells can use this function unguarded without causing animation code to run unnecessarily.