### PR TITLE
Fix shell link resolution always showing UI

### DIFF
--- a/src/ManagedShell.ShellFolders/ShellLinkHelper.cs
+++ b/src/ManagedShell.ShellFolders/ShellLinkHelper.cs
@@ -58,7 +58,14 @@ namespace ManagedShell.ShellFolders
                 persistFile.Load(existingLinkPath, (int)STGM.READ);
 
                 // attempt to resolve a broken shortcut
-                shellLink.Resolve(userInputHwnd, 0);
+                SLR_FLAGS flags = new SLR_FLAGS();
+
+                if (userInputHwnd == IntPtr.Zero)
+                {
+                    flags = SLR_FLAGS.SLR_NO_UI;
+                }
+
+                shellLink.Resolve(userInputHwnd, flags);
             }
             catch (Exception e)
             {


### PR DESCRIPTION
ShellLinkHelper.Load accepts an hwnd parameter to parent any UI shown by the link resolution process in case a broken shortcut is encountered. However, a shell may pass 0 in order to indicate no UI should be shown. This PR adds the necessary flag for that to actually happen.