### PR TITLE
Fix tray icons for apps that use the H.NotifyIcon library

### DIFF
--- a/src/ManagedShell.Interop/NativeMethods.User32.cs
+++ b/src/ManagedShell.Interop/NativeMethods.User32.cs
@@ -1546,7 +1546,12 @@ namespace ManagedShell.Interop
             /// <summary>
             /// Not implemented.
             /// </summary>
-            SPI_SETFONTSMOOTHINGORIENTATION = 0x2013,
+            SETFONTSMOOTHINGORIENTATION = 0x2013,
+
+            /// <summary>
+            /// Retrieves the time that notification pop-ups should be displayed, in seconds.
+            /// </summary>
+            GETMESSAGEDURATION = 0x2016,
         }
 
         [Flags]
@@ -1684,6 +1689,9 @@ namespace ManagedShell.Interop
 
         [DllImport(User32_DllName)]
         public static extern bool SystemParametersInfo(SPI uiAction, uint uiParam, IntPtr pvParam, SPIF fWinIni);
+
+        [DllImport(User32_DllName)]
+        public static extern bool SystemParametersInfo(SPI uiAction, uint uiParam, ref uint pvParam, SPIF fWinIni);
 
         [DllImport(User32_DllName, SetLastError = true)]
         public static extern IntPtr SetParent(IntPtr hWndChild, IntPtr hWndNewParent);

--- a/src/ManagedShell.WindowsTray/NotificationBalloon.cs
+++ b/src/ManagedShell.WindowsTray/NotificationBalloon.cs
@@ -34,7 +34,19 @@ namespace ManagedShell.WindowsTray
             Title = nicData.szInfoTitle;
             Info = nicData.szInfo;
             Flags = nicData.dwInfoFlags;
-            Timeout = (int)nicData.uVersion;
+            if ((int)nicData.uVersion >= 1000)
+            {
+                // Potentially valid timeout provided
+                Timeout = (int)nicData.uVersion;
+            }
+            else
+            {
+                // Fall back to the system duration
+                uint timeoutDuration = 5;
+                SystemParametersInfo(SPI.GETMESSAGEDURATION, 0, ref timeoutDuration, SPIF.None);
+                // Convert from sec to msec
+                Timeout = (int)timeoutDuration * 1000;
+            }
             Received = DateTime.Now;
 
             if (Flags.HasFlag(NIIF.ERROR))


### PR DESCRIPTION
Currently tray icons from apps that are using the [H.NotifyIcon library](https://github.com/HavenDV/H.NotifyIcon) are not working properly. The two issues are fixed in the PR:

1. Icon update messages are coming with a GUID instead of an HWnd. Previously we ignored these messages; now we handle them using the GUID.
2. Balloon messages were coming with a `0` value for the timeout (which makes sense, Explorer does not honor the timeout anyway). Now we use the system default timeout in this scenario.

An example application with this library is [DS4Windows](https://github.com/Ryochan7/DS4Windows/releases/), which was reported in dremin/RetroBar#730.