### PR TITLE
Make DpiScale observable

### DIFF
--- a/src/ManagedShell.AppBar/AppBarWindow.cs
+++ b/src/ManagedShell.AppBar/AppBarWindow.cs
@@ -18,9 +18,26 @@ namespace ManagedShell.AppBar
         protected readonly AppBarManager _appBarManager;
         protected readonly ExplorerHelper _explorerHelper;
         protected readonly FullScreenHelper _fullScreenHelper;
+
         public AppBarScreen Screen;
-        public double DpiScale = 1.0;
         protected bool ProcessScreenChanges = true;
+
+        private double _dpiScale = 1.0;
+        public double DpiScale
+        {
+            get
+            {
+                return _dpiScale;
+            }
+            set
+            {
+                if (_dpiScale != value)
+                {
+                    _dpiScale = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
 
         // Window properties
         private WindowInteropHelper helper;


### PR DESCRIPTION
Adds property change notification to AppBarWindow's DpiScale. This makes it easier for shells to update other properties based on DPI changes.