### PR TITLE
Improve tray icons in Windows 11 22H2+

### DIFF
--- a/src/ManagedShell.Common/Helpers/EnvironmentHelper.cs
+++ b/src/ManagedShell.Common/Helpers/EnvironmentHelper.cs
@@ -109,6 +109,19 @@ namespace ManagedShell.Common.Helpers
             }
         }
 
+        public static bool IsWindows1123H2OrBetter
+        {
+            get
+            {
+                if (osVersionMajor == 0)
+                {
+                    getOSVersion();
+                }
+
+                return (osVersionMajor >= 10 && osVersionBuild >= 22631);
+            }
+        }
+
         public static bool IsWindows10DarkModeSupported
         {
             get

--- a/src/ManagedShell.Common/Helpers/EnvironmentHelper.cs
+++ b/src/ManagedShell.Common/Helpers/EnvironmentHelper.cs
@@ -109,7 +109,7 @@ namespace ManagedShell.Common.Helpers
             }
         }
 
-        public static bool IsWindows1123H2OrBetter
+        public static bool IsWindows1122H2OrBetter
         {
             get
             {
@@ -118,7 +118,7 @@ namespace ManagedShell.Common.Helpers
                     getOSVersion();
                 }
 
-                return (osVersionMajor >= 10 && osVersionBuild >= 22631);
+                return (osVersionMajor >= 10 && osVersionBuild >= 22621);
             }
         }
 

--- a/src/ManagedShell.WindowsTray/NotificationArea.cs
+++ b/src/ManagedShell.WindowsTray/NotificationArea.cs
@@ -31,7 +31,12 @@ namespace ManagedShell.WindowsTray
             VOLUME_GUID
         };
 
-        internal static readonly List<string> Win11ActionCenterIcons = new List<string>()
+        internal static readonly List<string> Win11ActionCenterIcons = EnvironmentHelper.IsWindows1123H2OrBetter ? new List<string>()
+        {
+            // In 23H2, the Network icon reliably responds to click events!
+            POWER_GUID,
+            VOLUME_GUID
+        } : new List<string>()
         {
             NETWORK_GUID,
             POWER_GUID,

--- a/src/ManagedShell.WindowsTray/NotificationArea.cs
+++ b/src/ManagedShell.WindowsTray/NotificationArea.cs
@@ -31,10 +31,9 @@ namespace ManagedShell.WindowsTray
             VOLUME_GUID
         };
 
-        internal static readonly List<string> Win11ActionCenterIcons = EnvironmentHelper.IsWindows1123H2OrBetter ? new List<string>()
+        internal static readonly List<string> Win11ActionCenterIcons = EnvironmentHelper.IsWindows1122H2OrBetter ? new List<string>()
         {
-            // In 23H2, the Network icon reliably responds to click events!
-            POWER_GUID,
+            // In 22H2, the network and power flyouts work again
             VOLUME_GUID
         } : new List<string>()
         {

--- a/src/ManagedShell.WindowsTray/NotifyIcon.cs
+++ b/src/ManagedShell.WindowsTray/NotifyIcon.cs
@@ -544,7 +544,7 @@ namespace ManagedShell.WindowsTray
                     ShellHelper.ShowActionCenter();
                 }
 
-                if (!EnvironmentHelper.IsWindows1123H2OrBetter)
+                if (!EnvironmentHelper.IsWindows1122H2OrBetter)
                 {
                     // Some earlier Windows 11 versions have a crash when sending click events
                     return true;

--- a/src/ManagedShell.WindowsTray/NotifyIcon.cs
+++ b/src/ManagedShell.WindowsTray/NotifyIcon.cs
@@ -544,7 +544,11 @@ namespace ManagedShell.WindowsTray
                     ShellHelper.ShowActionCenter();
                 }
 
-                return true;
+                if (!EnvironmentHelper.IsWindows1123H2OrBetter)
+                {
+                    // Some earlier Windows 11 versions have a crash when sending click events
+                    return true;
+                }
             }
 
             return false;


### PR DESCRIPTION
A few improvements:

1. In the original Windows 11 release, sending a mouse click to the network or power icons crashed ShellExperienceHost. In 22H2 it now shows a flyout as expected, so go back to just sending a mouse click if we're on 22H2.
2. Some legacy shell enablers such as StartAllBack break the action center keyboard shortcut, but restore the click-able sound icon. This means that only sending a keyboard shortcut doesn't work. On 22H2, since it is now safe to do so, send both the mouse click and the keyboard shortcut to cover all scenarios.