### PR TITLE
Fix auto-hide getting stuck when there is no context menu

### DIFF
--- a/src/ManagedShell.AppBar/AppBarWindow.cs
+++ b/src/ManagedShell.AppBar/AppBarWindow.cs
@@ -7,6 +7,7 @@ using System.Runtime.CompilerServices;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Interop;
+using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Threading;
 using Application = System.Windows.Application;
@@ -385,7 +386,11 @@ namespace ManagedShell.AppBar
 
         private void AppBarWindow_ContextMenuOpening(object sender, ContextMenuEventArgs e)
         {
-            SetAutoHideStateVar(ref _isContextMenuOpen, true);
+            // ContextMenuOpening fires even if the element has no context menu defined, so we must check
+            if (HasContextMenu(e.OriginalSource as FrameworkElement))
+            {
+                SetAutoHideStateVar(ref _isContextMenuOpen, true);
+            }
         }
 
         private void AppBarWindow_PreviewDragEnter(object sender, DragEventArgs e)
@@ -586,6 +591,24 @@ namespace ManagedShell.AppBar
                 Topmost = true;
                 WindowHelper.ShowWindowTopMost(Handle);
                 IsRaising = false;
+            }
+        }
+
+        private bool HasContextMenu(FrameworkElement fe)
+        {
+            if (fe == null)
+            {
+                return false;
+            }
+
+            if (fe.ContextMenu != null)
+            {
+                return true;
+            }
+            else
+            {
+                var parent = VisualTreeHelper.GetParent(fe) as FrameworkElement;
+                return HasContextMenu(parent);
             }
         }
 

--- a/src/ManagedShell.WindowsTray/NotifyIcon.cs
+++ b/src/ManagedShell.WindowsTray/NotifyIcon.cs
@@ -197,7 +197,7 @@ namespace ManagedShell.WindowsTray
             set;
         }
 
-        private string Identifier
+        public string Identifier
         {
             get
             {


### PR DESCRIPTION
The ContextMenuOpening event is called even if no elements nor their parents have a contextmenu. This caused the appbar to think a menu was open when none was, getting it stuck. By recursively checking for a contextmenu, we can fix this.

Also made a notifyicon property public, because it is useful.