### PR TITLE
Fix a couple hardcoded %WINDIR% paths

### DIFF
--- a/src/ManagedShell.Common/Helpers/IconHelper.cs
+++ b/src/ManagedShell.Common/Helpers/IconHelper.cs
@@ -168,7 +168,7 @@ namespace ManagedShell.Common.Helpers
         {
             if (filename.EndsWith(".settingcontent-ms"))
             {
-                return "C:\\Windows\\ImmersiveControlPanel\\SystemSettings.exe";
+                return Environment.GetEnvironmentVariable("WINDIR") + "\\ImmersiveControlPanel\\SystemSettings.exe";
             }
 
             return filename;

--- a/src/ManagedShell.Common/Helpers/ShellHelper.cs
+++ b/src/ManagedShell.Common/Helpers/ShellHelper.cs
@@ -200,7 +200,7 @@ namespace ManagedShell.Common.Helpers
             owProc.StartInfo.UseShellExecute = true;
             owProc.StartInfo.FileName = Environment.GetEnvironmentVariable("WINDIR") + @"\system32\rundll32.exe";
             owProc.StartInfo.Arguments =
-                @"C:\WINDOWS\system32\shell32.dll,OpenAs_RunDLL " + fileName;
+                Environment.GetEnvironmentVariable("WINDIR") + @"\system32\shell32.dll,OpenAs_RunDLL " + fileName;
             owProc.Start();
         }
 


### PR DESCRIPTION
It's possible, albeit uncommon, for the drive letter and/or Windows folder name to differ for users. For example, someone who upgraded from Windows 2000 may have the path D:\WINNT\system32.