### PR TITLE
Allow shell to start or stop the folder change watcher after the folder is initialized

### DIFF
--- a/src/ManagedShell.ShellFolders/ShellFolder.cs
+++ b/src/ManagedShell.ShellFolders/ShellFolder.cs
@@ -404,12 +404,9 @@ namespace ManagedShell.ShellFolders
         public new void Dispose()
         {
             _isDisposed = true;
-            if (_changeWatcher != null)
-            {
-                _changeWatcher.Dispose();
-                _changeWatcher = null;
-            }
-            
+            StopWatchingChanges();
+
+
             try
             {
                 if (_files != null)

--- a/src/ManagedShell.ShellFolders/ShellFolder.cs
+++ b/src/ManagedShell.ShellFolders/ShellFolder.cs
@@ -100,12 +100,12 @@ namespace ManagedShell.ShellFolders
 
                 if (watchChanges)
                 {
-                    BeginWatchingChanges();
+                    InitChangeWatcher();
                 }
             }
         }
 
-        public void BeginWatchingChanges()
+        private void InitChangeWatcher()
         {
             if (_changeWatcher != null || _shellItem == null || !IsFileSystem || !IsFolder)
             {
@@ -113,6 +113,12 @@ namespace ManagedShell.ShellFolders
             }
 
             _changeWatcher = new ChangeWatcher(_watchList, ChangedEventHandler, CreatedEventHandler, DeletedEventHandler, RenamedEventHandler);
+        }
+
+        public void BeginWatchingChanges()
+        {
+            InitChangeWatcher();
+            _changeWatcher?.StartWatching();
         }
 
         public void StopWatchingChanges()

--- a/src/ManagedShell.ShellFolders/ShellFolder.cs
+++ b/src/ManagedShell.ShellFolders/ShellFolder.cs
@@ -18,10 +18,11 @@ namespace ManagedShell.ShellFolders
 
         private readonly IntPtr _hwndInput;
         private readonly bool _loadAsync;
-        private readonly ChangeWatcher _changeWatcher;
+        private ChangeWatcher _changeWatcher;
 
         private bool _isDisposed;
         private IntPtr _shellFolderPtr;
+        private List<string> _watchList = new List<string>();
 
         public bool IsDesktop { get; private set; }
 
@@ -82,10 +83,7 @@ namespace ManagedShell.ShellFolders
 
             if (_shellItem != null && IsFileSystem && IsFolder)
             {
-                List<string> watchList = new List<string>
-                {
-                    Path
-                };
+                _watchList.Add(Path);
 
                 if (IsDesktop)
                 {
@@ -96,15 +94,36 @@ namespace ManagedShell.ShellFolders
 
                     if (!string.IsNullOrEmpty(publicDesktopPath))
                     {
-                        watchList.Add(publicDesktopPath);
+                        _watchList.Add(publicDesktopPath);
                     }
                 }
 
                 if (watchChanges)
                 {
-                    _changeWatcher = new ChangeWatcher(watchList, ChangedEventHandler, CreatedEventHandler, DeletedEventHandler, RenamedEventHandler);
+                    BeginWatchingChanges();
                 }
             }
+        }
+
+        public void BeginWatchingChanges()
+        {
+            if (_changeWatcher != null || _shellItem == null || !IsFileSystem || !IsFolder)
+            {
+                return;
+            }
+
+            _changeWatcher = new ChangeWatcher(_watchList, ChangedEventHandler, CreatedEventHandler, DeletedEventHandler, RenamedEventHandler);
+        }
+
+        public void StopWatchingChanges()
+        {
+            if (_changeWatcher == null)
+            {
+                return;
+            }
+
+            _changeWatcher.Dispose();
+            _changeWatcher = null;
         }
 
         private void HandleDesktopFolder(string parsingName)
@@ -385,7 +404,11 @@ namespace ManagedShell.ShellFolders
         public new void Dispose()
         {
             _isDisposed = true;
-            _changeWatcher?.Dispose();
+            if (_changeWatcher != null)
+            {
+                _changeWatcher.Dispose();
+                _changeWatcher = null;
+            }
             
             try
             {


### PR DESCRIPTION
The shell may wish to temporarily disable the folder change watcher, as it blocks things such as device removal.