### PR TITLE
Forward some Explorer messages via PostMessage

### DIFF
--- a/src/ManagedShell.Interop/NativeMethods.User32.cs
+++ b/src/ManagedShell.Interop/NativeMethods.User32.cs
@@ -3014,6 +3014,9 @@ namespace ManagedShell.Interop
         [DllImport(User32_DllName)]
         public static extern bool PostMessage(int hWnd, uint msg, int wParam, long lParam);
 
+        [DllImport(User32_DllName)]
+        public static extern bool PostMessage(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam);
+
         public enum KLF : uint
         {
             ACTIVATE = 0x00000001,

--- a/src/ManagedShell.WindowsTray/TrayService.cs
+++ b/src/ManagedShell.WindowsTray/TrayService.cs
@@ -11,6 +11,7 @@ namespace ManagedShell.WindowsTray
     {
         private const string NotifyWndClass = "TrayNotifyWnd";
         private const string TrayWndClass = "Shell_TrayWnd";
+        private readonly int[] ForwardMessagesPost = { (int)WM.USER + 372 };
 
         private AppBarMessageDelegate appBarMessageDelegate;
         private IconDataDelegate iconDataDelegate;
@@ -267,6 +268,15 @@ namespace ManagedShell.WindowsTray
 
             if (HwndFwd != IntPtr.Zero)
             {
+                foreach (int postFwdMsg in ForwardMessagesPost)
+                {
+                    if (msg == postFwdMsg)
+                    {
+                        ShellLogger.Debug($"TrayService: Forwarding message via PostMessage: {msg}");
+                        PostMessage(HwndFwd, (uint)msg, wParam, lParam);
+                        return DefWindowProc(hWnd, msg, wParam, lParam);
+                    }
+                }
                 return SendMessage(HwndFwd, msg, wParam, lParam);
             }
 

--- a/src/ManagedShell.WindowsTray/TrayService.cs
+++ b/src/ManagedShell.WindowsTray/TrayService.cs
@@ -1,6 +1,7 @@
 using ManagedShell.Common.Helpers;
 using ManagedShell.Common.Logging;
 using System;
+using System.Linq;
 using System.Runtime.InteropServices;
 using System.Windows.Threading;
 using static ManagedShell.Interop.NativeMethods;
@@ -268,14 +269,11 @@ namespace ManagedShell.WindowsTray
 
             if (HwndFwd != IntPtr.Zero)
             {
-                foreach (int postFwdMsg in ForwardMessagesPost)
+                if (msg >= (int)WM.USER && ForwardMessagesPost.Contains(msg))
                 {
-                    if (msg == postFwdMsg)
-                    {
-                        ShellLogger.Debug($"TrayService: Forwarding message via PostMessage: {msg}");
-                        PostMessage(HwndFwd, (uint)msg, wParam, lParam);
-                        return DefWindowProc(hWnd, msg, wParam, lParam);
-                    }
+                    ShellLogger.Debug($"TrayService: Forwarding message via PostMessage: {msg}");
+                    PostMessage(HwndFwd, (uint)msg, wParam, lParam);
+                    return DefWindowProc(hWnd, msg, wParam, lParam);
                 }
                 return SendMessage(HwndFwd, msg, wParam, lParam);
             }


### PR DESCRIPTION
This message is always posted when Explorer restarts, and when we forward it back via `SendMessage`, Explorer enters a crash loop on recent Windows 11. Forwarding it via `PostMessage` avoids crashing Explorer.

This should fix the following:
https://github.com/dremin/RetroBar/pull/945
https://github.com/dremin/RetroBar/issues/942
https://github.com/dremin/RetroBar/issues/938
https://github.com/dremin/RetroBar/issues/927
https://github.com/dremin/RetroBar/issues/648
https://github.com/dremin/RetroBar/issues/476
https://github.com/dremin/RetroBar/issues/457