### PR TITLE
Handle when the 'hidden' attribute changes

### DIFF
--- a/src/ManagedShell.ShellFolders/ChangeWatcher.cs
+++ b/src/ManagedShell.ShellFolders/ChangeWatcher.cs
@@ -31,7 +31,7 @@ namespace ManagedShell.ShellFolders
                 {
                     FileSystemWatcher watcher = new FileSystemWatcher(path)
                     {
-                        NotifyFilter = NotifyFilters.DirectoryName | NotifyFilters.FileName | NotifyFilters.LastWrite | NotifyFilters.Size
+                        NotifyFilter = NotifyFilters.Attributes | NotifyFilters.DirectoryName | NotifyFilters.FileName | NotifyFilters.LastWrite | NotifyFilters.Size
                     };
 
                     watcher.Changed += _changedEventHandler;

--- a/src/ManagedShell.ShellFolders/ShellFolder.cs
+++ b/src/ManagedShell.ShellFolders/ShellFolder.cs
@@ -257,13 +257,21 @@ namespace ManagedShell.ShellFolders
                     if (file.Path == e.FullPath)
                     {
                         exists = true;
-                        file.Refresh();
+
+                        if (FileIsHidden(file.Path))
+                        {
+                            RemoveFile(file.Path);
+                        }
+                        else
+                        {
+                            file.Refresh();
+                        }
 
                         break;
                     }
                 }
 
-                if (!exists)
+                if (!exists && !FileIsHidden(e.FullPath))
                 {
                     AddFile(e.FullPath);
                 }
@@ -276,7 +284,7 @@ namespace ManagedShell.ShellFolders
             {
                 ShellLogger.Info($"ShellFolder: Item {e.ChangeType}: {e.Name} ({e.FullPath})");
 
-                if (!FileExists(e.FullPath))
+                if (!FileExists(e.FullPath) && !FileIsHidden(e.FullPath))
                 {
                     AddFile(e.FullPath);
                 }
@@ -301,7 +309,7 @@ namespace ManagedShell.ShellFolders
 
                 int existing = RemoveFile(e.OldFullPath);
 
-                if (!FileExists(e.FullPath))
+                if (!FileExists(e.FullPath) && !FileIsHidden(e.FullPath))
                 {
                     AddFile(e.FullPath, existing);
                 }
@@ -404,6 +412,23 @@ namespace ManagedShell.ShellFolders
             }
 
             return exists;
+        }
+
+        private bool FileIsHidden(string parsingName)
+        {
+            try
+            {
+                FileAttributes attributes = File.GetAttributes(parsingName);
+                if ((attributes & FileAttributes.Hidden) == FileAttributes.Hidden)
+                {
+                    return true;
+                }
+            }
+            catch (Exception ex)
+            {
+                ShellLogger.Warning($"ShellFolder: Unable to retrieve attributes for {parsingName}: {ex.Message}");
+            }
+            return false;
         }
         #endregion
 


### PR DESCRIPTION
Currently the ShellFolders implementation does not properly handle hidden files:
- If a new hidden file is created, we don't check this and will still add the file to the collection, so it will be visible
- If a hidden file is renamed or modified, we will see that the file is not in the collection and add it, so it becomes visible
- If a visible file becomes hidden, the ChangeWatcher does not receive a notification of this and it remains visible

This PR fixes all of the above items.