### PR TITLE
Handle cloak event to improve virtual desktop behavior

### DIFF
--- a/src/ManagedShell.Interop/NativeMethods.User32.cs
+++ b/src/ManagedShell.Interop/NativeMethods.User32.cs
@@ -1916,6 +1916,7 @@ namespace ManagedShell.Interop
         public static IntPtr HWND_BROADCAST = new IntPtr(0xffff);
         public static int WINEVENT_OUTOFCONTEXT = 0;
         public static int WINEVENT_SKIPOWNPROCESS = 2;
+        public static int EVENT_OBJECT_CLOAKED = 0x8017;
         public static int EVENT_OBJECT_UNCLOAKED = 0x8018;
         public static int EVENT_OBJECT_LOCATIONCHANGE = 0x800B;
 

--- a/src/ManagedShell.WindowsTasks/ApplicationWindow.cs
+++ b/src/ManagedShell.WindowsTasks/ApplicationWindow.cs
@@ -411,13 +411,6 @@ namespace ManagedShell.WindowsTasks
             return desc;
         }
 
-        internal void Uncloak()
-        {
-            ShellLogger.Debug($"ApplicationWindow: Uncloak event received for {Title}");
-
-            SetShowInTaskbar();
-        }
-
         private void setIcon()
         {
             if (!_iconLoading && ShowInTaskbar)


### PR DESCRIPTION
When switching virtual desktops, DWM marks all windows not on the current desktop as cloaked to hide them from the user and from the task switcher. We already had support for showing windows in the taskbar in response to the uncloak event; this PR adds support for hiding windows from the taskbar in response to the cloak event.

A good explanation regarding cloaked windows is [here](https://devblogs.microsoft.com/oldnewthing/20200302-00/?p=103507).