### PR TITLE
Add helper method for getting shortcut target

### DIFF
--- a/src/ManagedShell.Common/Helpers/ShellHelper.cs
+++ b/src/ManagedShell.Common/Helpers/ShellHelper.cs
@@ -403,6 +403,7 @@ namespace ManagedShell.Common.Helpers
                 StringBuilder outAumid = new StringBuilder((int)len);
 
                 GetApplicationUserModelId(hProcess, ref len, outAumid);
+                CloseHandle((int)hProcess);
 
                 if (outAumid.Length > 0)
                 {

--- a/src/ManagedShell.Interop/NativeMethods.Msi.cs
+++ b/src/ManagedShell.Interop/NativeMethods.Msi.cs
@@ -1,0 +1,16 @@
+﻿using System.Runtime.InteropServices;
+using System.Text;
+
+namespace ManagedShell.Interop
+{
+    public partial class NativeMethods
+    {
+        const string Msi_DllName = "msi.dll";
+
+        [DllImport(Msi_DllName, CharSet = CharSet.Unicode)]
+        public static extern uint MsiGetShortcutTarget(string szShortcutTarget, [Out] StringBuilder szProductCode, [Out] StringBuilder szFeatureId, [Out] StringBuilder szComponentCode);
+
+        [DllImport(Msi_DllName, CharSet = CharSet.Unicode)]
+        public static extern int MsiGetComponentPath(string szProduct, string szComponent, [Out] StringBuilder lpPathBuf, [In, Out] ref int pcchBuf);
+    }
+}

--- a/src/ManagedShell.ShellFolders/ShellLinkHelper.cs
+++ b/src/ManagedShell.ShellFolders/ShellLinkHelper.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.ComTypes;
+using System.Text;
 using ManagedShell.Common.Logging;
+using ManagedShell.Interop;
 using ManagedShell.ShellFolders.Enums;
 using ManagedShell.ShellFolders.Interfaces;
 
@@ -73,6 +75,58 @@ namespace ManagedShell.ShellFolders
             }
 
             return shellLink;
+        }
+
+        public static string GetLinkTarget(IntPtr userInputHwnd, string filePath)
+        {
+            IShellLink link = Load(userInputHwnd, filePath);
+            string target = "";
+
+            // First, query Windows Installer to see if this is an installed application shortcut
+            StringBuilder product = new StringBuilder(39);
+            StringBuilder feature = new StringBuilder(39);
+            StringBuilder component = new StringBuilder(39);
+
+            uint result = NativeMethods.MsiGetShortcutTarget(filePath, product, feature, component);
+
+            if (result == 0)
+            {
+                // This is a Windows Installer shortcut
+                int pathLength = 1024;
+                StringBuilder path = new StringBuilder(pathLength);
+                int installState = NativeMethods.MsiGetComponentPath(product.ToString(), component.ToString(), path, ref pathLength);
+                if (installState == 1)
+                {
+                    // Locally installed application
+                    target = path.ToString();
+                }
+            }
+
+            if (string.IsNullOrEmpty(target))
+            {
+                // Check for an associated identifier list to get an IShellItem object from
+                IntPtr pidl = IntPtr.Zero;
+                link.GetIDList(out pidl);
+
+                if (pidl != IntPtr.Zero)
+                {
+                    IShellItem _shellItem;
+                    Interop.SHCreateItemFromIDList(pidl, typeof(IShellItem).GUID, out _shellItem);
+                    ShellItem item = new ShellItem(_shellItem);
+                    target = item.Path;
+                    string aumid = item.GetAumid();
+                }
+            }
+
+            if (string.IsNullOrEmpty(target))
+            {
+                // Get the shortcut path as a last resort
+                StringBuilder builder = new StringBuilder(260);
+                link.GetPath(builder, 260, out Structs.WIN32_FIND_DATA pfd, SLGP_FLAGS.SLGP_RAWPATH);
+                target = builder.ToString();
+            }
+
+            return target;
         }
     }
 }

--- a/src/ManagedShell.ShellFolders/ShellLinkHelper.cs
+++ b/src/ManagedShell.ShellFolders/ShellLinkHelper.cs
@@ -82,48 +82,68 @@ namespace ManagedShell.ShellFolders
             IShellLink link = Load(userInputHwnd, filePath);
             string target = "";
 
-            // First, query Windows Installer to see if this is an installed application shortcut
-            StringBuilder product = new StringBuilder(39);
-            StringBuilder feature = new StringBuilder(39);
-            StringBuilder component = new StringBuilder(39);
-
-            uint result = NativeMethods.MsiGetShortcutTarget(filePath, product, feature, component);
-
-            if (result == 0)
+            try
             {
-                // This is a Windows Installer shortcut
-                int pathLength = 1024;
-                StringBuilder path = new StringBuilder(pathLength);
-                int installState = NativeMethods.MsiGetComponentPath(product.ToString(), component.ToString(), path, ref pathLength);
-                if (installState == 1)
+                // First, query Windows Installer to see if this is an installed application shortcut
+                StringBuilder product = new StringBuilder(39);
+                StringBuilder feature = new StringBuilder(39);
+                StringBuilder component = new StringBuilder(39);
+
+                uint result = NativeMethods.MsiGetShortcutTarget(filePath, product, feature, component);
+
+                if (result == 0)
                 {
-                    // Locally installed application
-                    target = path.ToString();
+                    // This is a Windows Installer shortcut
+                    int pathLength = 1024;
+                    StringBuilder path = new StringBuilder(pathLength);
+                    int installState = NativeMethods.MsiGetComponentPath(product.ToString(), component.ToString(), path, ref pathLength);
+                    if (installState == 1)
+                    {
+                        // Locally installed application
+                        target = path.ToString();
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                ShellLogger.Error($"ShellLinkHelper: Unable to query Windows Installer target for {filePath}", e);
+            }
+
+            if (string.IsNullOrEmpty(target))
+            {
+                try
+                {
+                    // Check for an associated identifier list to get an IShellItem object from
+                    IntPtr pidl = IntPtr.Zero;
+                    link.GetIDList(out pidl);
+
+                    if (pidl != IntPtr.Zero)
+                    {
+                        IShellItem _shellItem;
+                        Interop.SHCreateItemFromIDList(pidl, typeof(IShellItem).GUID, out _shellItem);
+                        ShellItem item = new ShellItem(_shellItem);
+                        target = item.Path;
+                    }
+                }
+                catch (Exception e)
+                {
+                    ShellLogger.Error($"ShellLinkHelper: Unable to get ID list for {filePath}", e);
                 }
             }
 
             if (string.IsNullOrEmpty(target))
             {
-                // Check for an associated identifier list to get an IShellItem object from
-                IntPtr pidl = IntPtr.Zero;
-                link.GetIDList(out pidl);
-
-                if (pidl != IntPtr.Zero)
+                try
                 {
-                    IShellItem _shellItem;
-                    Interop.SHCreateItemFromIDList(pidl, typeof(IShellItem).GUID, out _shellItem);
-                    ShellItem item = new ShellItem(_shellItem);
-                    target = item.Path;
-                    string aumid = item.GetAumid();
+                    // Get the shortcut path as a last resort
+                    StringBuilder builder = new StringBuilder(260);
+                    link.GetPath(builder, 260, out Structs.WIN32_FIND_DATA pfd, SLGP_FLAGS.SLGP_RAWPATH);
+                    target = builder.ToString();
                 }
-            }
-
-            if (string.IsNullOrEmpty(target))
-            {
-                // Get the shortcut path as a last resort
-                StringBuilder builder = new StringBuilder(260);
-                link.GetPath(builder, 260, out Structs.WIN32_FIND_DATA pfd, SLGP_FLAGS.SLGP_RAWPATH);
-                target = builder.ToString();
+                catch (Exception e)
+                {
+                    ShellLogger.Error($"ShellLinkHelper: Unable to get path for {filePath}", e);
+                }
             }
 
             return target;


### PR DESCRIPTION
Many shortcuts point to Microsoft Installer packages or have an associated PIDL we can read from, which provides a more accurate target than the string returned by `IShellLink.GetPath()`. Added a helper method so shells don't need to do this themselves.

Also added a missing `CloseHandle` to another helper.