### PR TITLE
Fix window focus after minimize when not debugging

### DIFF
--- a/src/ManagedShell.WindowsTasks/ApplicationWindow.cs
+++ b/src/ManagedShell.WindowsTasks/ApplicationWindow.cs
@@ -588,7 +588,7 @@ namespace ManagedShell.WindowsTasks
             else
             {
                 // If the window is maximized, use ShowMaximize so that it doesn't un-maximize
-                if (GetWindowShowStyle(Handle) != NativeMethods.WindowShowStyle.ShowMaximized || 
+                if (GetWindowShowStyle(Handle) != NativeMethods.WindowShowStyle.ShowMaximized ||
                     !NativeMethods.ShowWindow(Handle, NativeMethods.WindowShowStyle.ShowMaximized))
                 {
                     NativeMethods.ShowWindow(Handle, NativeMethods.WindowShowStyle.Show);
@@ -603,8 +603,9 @@ namespace ManagedShell.WindowsTasks
         {
             if ((WindowStyles & (int)NativeMethods.WindowStyles.WS_MINIMIZEBOX) != 0)
             {
-                IntPtr retval = IntPtr.Zero;
-                NativeMethods.SendMessageTimeout(Handle, (int)NativeMethods.WM.SYSCOMMAND, NativeMethods.SC_MINIMIZE, 0, 2, 200, ref retval);
+                NativeMethods.GetWindowThreadProcessId(Handle, out uint procId);
+                NativeMethods.AllowSetForegroundWindow(procId);
+                NativeMethods.PostMessage(Handle, (int)NativeMethods.WM.SYSCOMMAND, (IntPtr)NativeMethods.SC_MINIMIZE, IntPtr.Zero);
             }
         }
 


### PR DESCRIPTION
When minimizing a window, it needs the ability to move focus the next window in the z-order. Previously this only worked when a debugger was attached to the shell, but this makes it work always. This fixes the problem described in https://github.com/dremin/RetroBar/issues/783.