### PR TITLE
Window management improvements and fixes

### DIFF
--- a/src/ManagedShell.AppBar/AppBarWindow.cs
+++ b/src/ManagedShell.AppBar/AppBarWindow.cs
@@ -480,7 +480,7 @@ namespace ManagedShell.AppBar
                     DpiHelper.DpiScale = DpiScale;
                 }
 
-                // if we are opening, because we're getting this message as a result of positioning
+                // if we are opening, we're getting this message as a result of positioning
                 // if we are an AppBar, that code will fix our position, so skip in that case to prevent infinite resizing.
                 if (!IsOpening || AppBarMode != AppBarMode.Normal)
                 {

--- a/src/ManagedShell.AppBar/AppBarWindow.cs
+++ b/src/ManagedShell.AppBar/AppBarWindow.cs
@@ -480,8 +480,9 @@ namespace ManagedShell.AppBar
                     DpiHelper.DpiScale = DpiScale;
                 }
 
-                // suppress this if we are opening, because we're getting this message as a result of positioning
-                if (!IsOpening)
+                // if we are opening, because we're getting this message as a result of positioning
+                // if we are an AppBar, that code will fix our position, so skip in that case to prevent infinite resizing.
+                if (!IsOpening || AppBarMode != AppBarMode.Normal)
                 {
                     ProcessScreenChange(ScreenSetupReason.DpiChange);
                 }

--- a/src/ManagedShell.AppBar/FullScreenApp.cs
+++ b/src/ManagedShell.AppBar/FullScreenApp.cs
@@ -8,5 +8,6 @@ namespace ManagedShell.AppBar
         public IntPtr hWnd;
         public ScreenInfo screen;
         public NativeMethods.Rect rect;
+        public string title;
     }
 }

--- a/src/ManagedShell.AppBar/FullScreenHelper.cs
+++ b/src/ManagedShell.AppBar/FullScreenHelper.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
-using System.Text;
 using System.Windows.Forms;
 using System.Windows.Threading;
 using static ManagedShell.Interop.NativeMethods;
@@ -28,6 +27,7 @@ namespace ManagedShell.AppBar
                 // On Windows 8 and newer, TasksService will tell us when windows enter and exit full screen
                 _tasksService.FullScreenEntered += TasksService_Event;
                 _tasksService.FullScreenLeft += TasksService_Event;
+                _tasksService.MonitorChanged += TasksService_Event;
                 _tasksService.DesktopActivated += TasksService_Event;
                 _tasksService.WindowActivated += TasksService_Event;
                 return;
@@ -214,6 +214,7 @@ namespace ManagedShell.AppBar
             {
                 _tasksService.FullScreenEntered -= TasksService_Event;
                 _tasksService.FullScreenLeft -= TasksService_Event;
+                _tasksService.MonitorChanged -= TasksService_Event;
                 _tasksService.DesktopActivated -= TasksService_Event;
                 _tasksService.WindowActivated -= TasksService_Event;
                 return;

--- a/src/ManagedShell.AppBar/ManagedShell.AppBar.csproj
+++ b/src/ManagedShell.AppBar/ManagedShell.AppBar.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <ProjectReference Include="..\ManagedShell.Common\ManagedShell.Common.csproj" />
     <ProjectReference Include="..\ManagedShell.Interop\ManagedShell.Interop.csproj" />
+	<ProjectReference Include="..\ManagedShell.WindowsTasks\ManagedShell.WindowsTasks.csproj" />
     <ProjectReference Include="..\ManagedShell.WindowsTray\ManagedShell.WindowsTray.csproj" />
   </ItemGroup>
 

--- a/src/ManagedShell.Common/SupportingClasses/NativeWindowEx.cs
+++ b/src/ManagedShell.Common/SupportingClasses/NativeWindowEx.cs
@@ -4,14 +4,19 @@ namespace ManagedShell.Common.SupportingClasses
 {
     public class NativeWindowEx : NativeWindow
     {
-        public delegate void MessageReceivedEventHandler(Message m);
+        public delegate void MessageReceivedEventHandler(ref Message m, ref bool handled);
 
         public event MessageReceivedEventHandler MessageReceived;
 
         protected override void WndProc(ref Message m)
         {
-            base.WndProc(ref m);
-            MessageReceived?.Invoke(m);
+            bool handled = false;
+            MessageReceived?.Invoke(ref m, ref handled);
+
+            if (!handled)
+            {
+                base.WndProc(ref m);
+            }
         }
 
         public override void CreateHandle(CreateParams cp)

--- a/src/ManagedShell.Common/SupportingClasses/ShellWindow.cs
+++ b/src/ManagedShell.Common/SupportingClasses/ShellWindow.cs
@@ -23,7 +23,7 @@ namespace ManagedShell.Common.SupportingClasses
             cp.Y = SystemInformation.VirtualScreen.Top;
 
             CreateHandle(cp);
-            MessageReceived += WndProc;
+            MessageReceived += ShellWndProc;
             NativeMethods.SetWindowLong(Handle, NativeMethods.GWL_EXSTYLE, 
                 NativeMethods.GetWindowLong(Handle, NativeMethods.GWL_EXSTYLE) & 
                 ~(int)NativeMethods.ExtendedWindowStyles.WS_EX_NOACTIVATE);
@@ -47,7 +47,7 @@ namespace ManagedShell.Common.SupportingClasses
             NativeMethods.DestroyWindow(Handle);
         }
 
-        private void WndProc(Message msg)
+        private void ShellWndProc(ref Message msg, ref bool handled)
         {
             // Window procedure for the native window
             // Because other desktop windows are children, we need to pass them some received events.

--- a/src/ManagedShell.Interop/NativeMethods.User32.cs
+++ b/src/ManagedShell.Interop/NativeMethods.User32.cs
@@ -237,7 +237,7 @@ namespace ManagedShell.Interop
         public struct SHELLHOOKINFO
         {
             public IntPtr hwnd;
-            public Rect rc;
+            public ShortRect rc;
         }
 
         [StructLayout(LayoutKind.Sequential)]
@@ -320,6 +320,9 @@ namespace ManagedShell.Interop
 
         [DllImport(User32_DllName)]
         public static extern IntPtr GetParent(IntPtr handle);
+
+        [DllImport(User32_DllName)]
+        public static extern void SwitchToThisWindow(IntPtr hWnd, bool fAltTab);
 
         public struct WINDOWPLACEMENT
         {
@@ -1898,6 +1901,9 @@ namespace ManagedShell.Interop
         [DllImport(User32_DllName, SetLastError = true)]
         public static extern IntPtr RemoveProp(IntPtr hWnd, string lpString);
 
+        [DllImport(User32_DllName, SetLastError = true)]
+        public static extern IntPtr GetProp(IntPtr hWnd, string lpString);
+
         public enum TBPFLAG
         {
             TBPF_NOPROGRESS = 0,
@@ -2910,7 +2916,19 @@ namespace ManagedShell.Interop
             /// </summary>
             ENDTASK = 10,
             FLASH = (REDRAW | HSHELL_HIGHBIT),
-            RUDEAPPACTIVATED = (WINDOWACTIVATED | HSHELL_HIGHBIT)
+            RUDEAPPACTIVATED = (WINDOWACTIVATED | HSHELL_HIGHBIT),
+            /// <summary>
+            /// A window has moved to another monitor. Windows 8 and newer only.
+            /// </summary>
+            MONITORCHANGED = 16,
+            /// <summary>
+            /// A window has become full-screen. Windows 8 and newer only.
+            /// </summary>
+            FULLSCREENENTER = 53,
+            /// <summary>
+            /// A window has left full-screen. Windows 8 and newer only.
+            /// </summary>
+            FULLSCREENEXIT = 54
         }
 
         [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Ansi)]

--- a/src/ManagedShell.Interop/NativeMethods.User32.cs
+++ b/src/ManagedShell.Interop/NativeMethods.User32.cs
@@ -1701,6 +1701,9 @@ namespace ManagedShell.Interop
         public static extern bool IsWindowVisible(IntPtr hWnd);
 
         [DllImport(User32_DllName)]
+        public static extern bool IsWindowEnabled(IntPtr hWnd);
+
+        [DllImport(User32_DllName)]
         public static extern IntPtr SetWindowLong(IntPtr hWnd, int nIndex, int dwNewLong);
 
         [DllImport(User32_DllName, SetLastError = true)]

--- a/src/ManagedShell.Interop/NativeMethods.User32.cs
+++ b/src/ManagedShell.Interop/NativeMethods.User32.cs
@@ -321,9 +321,6 @@ namespace ManagedShell.Interop
         [DllImport(User32_DllName)]
         public static extern IntPtr GetParent(IntPtr handle);
 
-        [DllImport(User32_DllName)]
-        public static extern void SwitchToThisWindow(IntPtr hWnd, bool fAltTab);
-
         public struct WINDOWPLACEMENT
         {
             public int length;

--- a/src/ManagedShell.Interop/NativeMethods.cs
+++ b/src/ManagedShell.Interop/NativeMethods.cs
@@ -29,6 +29,30 @@ namespace ManagedShell.Interop
             public int Height => Bottom - Top;
         }
 
+        /// <summary>
+        /// Used by HSHELL_GETMINRECT
+        /// </summary>
+        [StructLayout(LayoutKind.Sequential)]
+        public struct ShortRect
+        {
+            public ShortRect(short left, short top, short right, short bottom)
+            {
+                Left = left;
+                Top = top;
+                Right = right;
+                Bottom = bottom;
+            }
+
+            public short Left;
+            public short Top;
+            public short Right;
+            public short Bottom;
+
+            public int Width => Right - Left;
+
+            public int Height => Bottom - Top;
+        }
+
         public struct POINT
         {
             public POINT(long x, long y)

--- a/src/ManagedShell.WindowsTasks/ApplicationWindow.cs
+++ b/src/ManagedShell.WindowsTasks/ApplicationWindow.cs
@@ -623,9 +623,23 @@ namespace ManagedShell.WindowsTasks
 
         public void BringToFront()
         {
-            makeForeground();
+            // call restore if window is minimized
+            if (IsMinimized)
+            {
+                Restore();
+            }
+            else
+            {
+                // If the window is maximized, use ShowMaximize so that it doesn't un-maximize
+                if (GetWindowShowStyle(Handle) != NativeMethods.WindowShowStyle.ShowMaximized ||
+                    !NativeMethods.ShowWindow(Handle, NativeMethods.WindowShowStyle.ShowMaximized))
+                {
+                    NativeMethods.ShowWindow(Handle, NativeMethods.WindowShowStyle.Show);
+                }
+                makeForeground();
 
-            if (State == WindowState.Flashing) State = WindowState.Active; // some stubborn windows (Outlook) start flashing while already active, this lets us stop
+                if (State == WindowState.Flashing) State = WindowState.Active; // some stubborn windows (Outlook) start flashing while already active, this lets us stop
+            }
         }
 
         public void Minimize()
@@ -662,7 +676,7 @@ namespace ManagedShell.WindowsTasks
 
         private void makeForeground()
         {
-            NativeMethods.SwitchToThisWindow(NativeMethods.GetLastActivePopup(Handle), true);
+            NativeMethods.SetForegroundWindow(NativeMethods.GetLastActivePopup(Handle));
         }
 
         internal IntPtr DoClose()

--- a/src/ManagedShell.WindowsTasks/ApplicationWindow.cs
+++ b/src/ManagedShell.WindowsTasks/ApplicationWindow.cs
@@ -361,7 +361,7 @@ namespace ManagedShell.WindowsTasks
             }
         }
 
-        public bool CanMinimize => (WindowStyles & (int)NativeMethods.WindowStyles.WS_MINIMIZEBOX) != 0;
+        public bool CanMinimize => (WindowStyles & (int)NativeMethods.WindowStyles.WS_MINIMIZEBOX) != 0 && NativeMethods.IsWindowEnabled(Handle);
 
         private bool? _showInTaskbar;
 

--- a/src/ManagedShell.WindowsTasks/ApplicationWindow.cs
+++ b/src/ManagedShell.WindowsTasks/ApplicationWindow.cs
@@ -20,6 +20,10 @@ namespace ManagedShell.WindowsTasks
         private readonly TasksService _tasksService;
         StringBuilder titleBuilder = new StringBuilder(TITLE_LENGTH);
 
+        public delegate void GetButtonRectEventHandler(ref NativeMethods.ShortRect rect);
+
+        public event GetButtonRectEventHandler GetButtonRect;
+
         public ApplicationWindow(TasksService tasksService, IntPtr handle)
         {
             _tasksService = tasksService;
@@ -555,6 +559,13 @@ namespace ManagedShell.WindowsTasks
         internal void SetMonitor()
         {
             HMonitor = NativeMethods.MonitorFromWindow(Handle, NativeMethods.MONITOR_DEFAULTTONEAREST);
+        }
+
+        internal NativeMethods.ShortRect GetButtonRectFromShell()
+        {
+            NativeMethods.ShortRect rect = new NativeMethods.ShortRect();
+            GetButtonRect?.Invoke(ref rect);
+            return rect;
         }
 
         public void SetOverlayIcon(IntPtr hIcon)

--- a/src/ManagedShell.WindowsTasks/TasksService.cs
+++ b/src/ManagedShell.WindowsTasks/TasksService.cs
@@ -18,10 +18,11 @@ namespace ManagedShell.WindowsTasks
     {
         public static readonly IconSize DEFAULT_ICON_SIZE = IconSize.Small;
 
-        public event EventHandler<WindowActivatedEventArgs> WindowActivated;
+        public event EventHandler<WindowEventArgs> WindowActivated;
         public event EventHandler<EventArgs> DesktopActivated;
         public event EventHandler<EventArgs> FullScreenEntered;
         public event EventHandler<EventArgs> FullScreenLeft;
+        public event EventHandler<WindowEventArgs> MonitorChanged;
 
         private NativeWindowEx _HookWin;
         private object _windowsLock = new object();
@@ -385,7 +386,7 @@ namespace ManagedShell.WindowsTasks
                                                 wind.SetShowInTaskbar();
                                         }
 
-                                        WindowActivatedEventArgs args = new WindowActivatedEventArgs
+                                        WindowEventArgs args = new WindowEventArgs
                                         {
                                             Window = win
                                         };
@@ -449,6 +450,13 @@ namespace ManagedShell.WindowsTasks
                                     ApplicationWindow win = Windows.First(wnd => wnd.Handle == msgCopy.LParam);
                                     win.SetMonitor();
                                     ShellLogger.Debug($"TasksService: Monitor changed for {win.Handle} ({win.Title})");
+
+                                    WindowEventArgs args = new WindowEventArgs
+                                    {
+                                        Window = win
+                                    };
+
+                                    MonitorChanged?.Invoke(this, args);
                                 }
                                 break;
 

--- a/src/ManagedShell.WindowsTasks/TasksService.cs
+++ b/src/ManagedShell.WindowsTasks/TasksService.cs
@@ -269,13 +269,15 @@ namespace ManagedShell.WindowsTasks
             if (initialState != ApplicationWindow.WindowState.Inactive) win.State = initialState;
 
             // add window unless we need to validate it is eligible to show in taskbar
-            if (!sanityCheck || win.CanAddToTaskbar) Windows.Add(win);
+            if (!sanityCheck || win.CanAddToTaskbar)
+            {
+                Windows.Add(win);
+                ShellLogger.Debug($"TasksService: Added window {hWnd} ({win.Title})");
+            }
 
             // Only send TaskbarButtonCreated if we are shell, and if OS is not Server Core
             // This is because if Explorer is running, it will send the message, so we don't need to
             if (EnvironmentHelper.IsAppRunningAsShell) sendTaskbarButtonCreatedMessage(win.Handle);
-
-            ShellLogger.Debug($"TasksService: Added window {hWnd} ({win.Title})");
 
             return win;
         }

--- a/src/ManagedShell.WindowsTasks/WindowEventArgs.cs
+++ b/src/ManagedShell.WindowsTasks/WindowEventArgs.cs
@@ -2,7 +2,7 @@
 
 namespace ManagedShell.WindowsTasks
 {
-    public class WindowActivatedEventArgs : EventArgs
+    public class WindowEventArgs : EventArgs
     {
         public ApplicationWindow Window;
     }

--- a/src/ManagedShell/ShellConfig.cs
+++ b/src/ManagedShell/ShellConfig.cs
@@ -24,6 +24,7 @@ namespace ManagedShell
         /// <summary>
         /// Controls whether the tasks service will be multi-mon aware when using AutoStartTasksService.<br />
         /// This keeps the HMonitor property of each ApplicationWindow updated.<br />
+        /// This setting applies only to Windows 7. The tasks service is always multi-mon aware on Windows 8 and newer.<br />
         /// <br />
         /// By default, this is enabled.
         /// </summary>

--- a/src/ManagedShell/ShellManager.cs
+++ b/src/ManagedShell/ShellManager.cs
@@ -46,7 +46,7 @@ namespace ManagedShell
                 Tasks = new Tasks(TasksService);
             }
 
-            FullScreenHelper = new FullScreenHelper();
+            FullScreenHelper = new FullScreenHelper(TasksService);
             ExplorerHelper = new ExplorerHelper(NotificationArea);
             AppBarManager = new AppBarManager(ExplorerHelper);
 


### PR DESCRIPTION
Performance improvements:
- Use new shell hook messages in Win8+ for handling window monitor changes instead of event hook
- Use new shell hook messages in Win8+ for full-screen app notifications
- Adapt FullScreenHelper to use new TasksService events instead of a timer on Win8+

Fix handling of the minimize/restore animation:
- Fixed NativeWindowEx message object passing so that the result value is actually used
- Fix broken handling of HSHELL_GETMINRECT
- Added event to ApplicationWindow that shells can handle to provide a button rect when requested that is used for HSHELL_GETMINRECT

Misc:
- Added some properties to ApplicationWindow to simplify other code
- Improve FullScreenHelper logic and logging
- Fix ResetScreenCache on newer .NET versions (https://github.com/cairoshell/ManagedShell/issues/100)
- Fix AppBarWindow initial position when on a secondary screen with high DPI and in auto-hide or no-appbar mode
- Fix disabled windows, which can't be restored, being allowed to minimize