### PR TITLE
AppBar fixes

### DIFF
--- a/src/ManagedShell.AppBar/AppBarManager.cs
+++ b/src/ManagedShell.AppBar/AppBarManager.cs
@@ -402,12 +402,14 @@ namespace ManagedShell.AppBar
 
                 // check if new coords
                 bool isSameCoords = false;
+                Rect currentRect;
+                GetWindowRect(abWindow.Handle, out currentRect);
                 if (!isCreate)
                 {
-                    bool topUnchanged = abd.rc.Top == Math.Round(abWindow.Top * abWindow.DpiScale);
-                    bool leftUnchanged = abd.rc.Left == Math.Round(abWindow.Left * abWindow.DpiScale);
-                    bool bottomUnchanged = abd.rc.Bottom == Math.Round((abWindow.Top * abWindow.DpiScale) + (abWindow.ActualHeight * abWindow.DpiScale));
-                    bool rightUnchanged = abd.rc.Right == Math.Round((abWindow.Left * abWindow.DpiScale) + (abWindow.ActualWidth * abWindow.DpiScale));
+                    bool topUnchanged = abd.rc.Top == currentRect.Top;
+                    bool leftUnchanged = abd.rc.Left == currentRect.Left;
+                    bool bottomUnchanged = abd.rc.Bottom == currentRect.Bottom;
+                    bool rightUnchanged = abd.rc.Right == currentRect.Right;
 
                     isSameCoords = topUnchanged
                                    && leftUnchanged
@@ -417,7 +419,7 @@ namespace ManagedShell.AppBar
 
                 if (!isSameCoords)
                 {
-                    ShellLogger.Debug($"AppBarManager: {abWindow.Name} changing position (TxLxBxR) to {abd.rc.Top}x{abd.rc.Left}x{abd.rc.Bottom}x{abd.rc.Right} from {abWindow.Top * abWindow.DpiScale}x{abWindow.Left * abWindow.DpiScale}x{Math.Round((abWindow.Top * abWindow.DpiScale) + (abWindow.ActualHeight * abWindow.DpiScale))}x{Math.Round((abWindow.Left * abWindow.DpiScale) + (abWindow.ActualWidth * abWindow.DpiScale))}");
+                    ShellLogger.Debug($"AppBarManager: {abWindow.Name} changing position (TxLxBxR) to {abd.rc.Top}x{abd.rc.Left}x{abd.rc.Bottom}x{abd.rc.Right} from {currentRect.Top}x{currentRect.Left}x{currentRect.Bottom}x{currentRect.Right}");
                     abWindow.SetAppBarPosition(abd.rc);
                 }
 

--- a/src/ManagedShell.AppBar/AppBarWindow.cs
+++ b/src/ManagedShell.AppBar/AppBarWindow.cs
@@ -53,6 +53,7 @@ namespace ManagedShell.AppBar
 
         // AppBar properties
         private int AppBarMessageId = -1;
+        private NativeMethods.Rect _lastAppBarRect;
 
         private AppBarEdge _appBarEdge;
         public AppBarEdge AppBarEdge
@@ -667,13 +668,14 @@ namespace ManagedShell.AppBar
         #region Virtual methods
         public virtual void AfterAppBarPos(bool isSameCoords, NativeMethods.Rect rect)
         {
+            _lastAppBarRect = rect;
             if (!isSameCoords)
             {
                 var timer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(0.1) };
                 timer.Tick += (sender1, args) =>
                 {
                     // set position again, since WPF may have overridden the original change from AppBarHelper
-                    SetAppBarPosition(rect);
+                    SetAppBarPosition(_lastAppBarRect);
 
                     timer.Stop();
                 };


### PR DESCRIPTION
- Get and use window coordinates in pixels instead of converting points to pixels when comparing AppBar rects
- Save latest AppBar rect in AppBarWindow, so that when multiple updates come quickly, the AppBar window does not bounce around any more due to the timer using stale data.