### PR TITLE
AppBar refactoring and improvements

### DIFF
--- a/src/ManagedShell.AppBar/AppBarWindow.cs
+++ b/src/ManagedShell.AppBar/AppBarWindow.cs
@@ -135,7 +135,6 @@ namespace ManagedShell.AppBar
             PropertyChanged += AppBarWindow_PropertyChanged;
 
             ResizeMode = ResizeMode.NoResize;
-            ShowInTaskbar = false;
             Title = "";
             Topmost = true;
             UseLayoutRounding = true;

--- a/src/ManagedShell.AppBar/AppBarWindow.cs
+++ b/src/ManagedShell.AppBar/AppBarWindow.cs
@@ -328,6 +328,24 @@ namespace ManagedShell.AppBar
             }
         }
 
+        protected virtual void OnFullScreenEnter()
+        {
+            ShellLogger.Debug($"AppBarWindow: {Name} on {Screen.DeviceName} conceding to full-screen app");
+
+            Topmost = false;
+            WindowHelper.ShowWindowBottomMost(Handle);
+        }
+
+        protected virtual void OnFullScreenLeave()
+        {
+            ShellLogger.Debug($"AppBarWindow: {Name} on {Screen.DeviceName} returning to normal state");
+
+            IsRaising = true;
+            Topmost = true;
+            WindowHelper.ShowWindowTopMost(Handle);
+            IsRaising = false;
+        }
+
         private void OnClosing(object sender, CancelEventArgs e)
         {
             IsClosing = true;
@@ -365,11 +383,11 @@ namespace ManagedShell.AppBar
 
             if (found && Topmost)
             {
-                setFullScreenMode(true);
+                OnFullScreenEnter();
             }
             else if (!found && !Topmost)
             {
-                setFullScreenMode(false);
+                OnFullScreenLeave();
             }
         }
 
@@ -565,26 +583,6 @@ namespace ManagedShell.AppBar
             if (((Screen.Primary && ProcessScreenChanges) || reason == ScreenSetupReason.DpiChange) && !AllowClose)
             {
                 SetScreenProperties(reason);
-            }
-        }
-
-        private void setFullScreenMode(bool entering)
-        {
-            if (entering)
-            {
-                ShellLogger.Debug($"AppBarWindow: {Name} on {Screen.DeviceName} conceding to full-screen app");
-
-                Topmost = false;
-                WindowHelper.ShowWindowBottomMost(Handle);
-            }
-            else
-            {
-                ShellLogger.Debug($"AppBarWindow: {Name} on {Screen.DeviceName} returning to normal state");
-
-                IsRaising = true;
-                Topmost = true;
-                WindowHelper.ShowWindowTopMost(Handle);
-                IsRaising = false;
             }
         }
 

--- a/src/ManagedShell.Common/Helpers/WindowHelper.cs
+++ b/src/ManagedShell.Common/Helpers/WindowHelper.cs
@@ -102,7 +102,7 @@ namespace ManagedShell.Common.Helpers
         
         public static void HideWindowFromTasks(IntPtr hWnd)
         {
-            SetWindowLong(hWnd, GWL_EXSTYLE, GetWindowLong(hWnd, GWL_EXSTYLE) | (int)ExtendedWindowStyles.WS_EX_TOOLWINDOW);
+            SetWindowLong(hWnd, GWL_EXSTYLE, (GetWindowLong(hWnd, GWL_EXSTYLE) & ~(int)ExtendedWindowStyles.WS_EX_APPWINDOW) | (int)ExtendedWindowStyles.WS_EX_TOOLWINDOW);
 
             ExcludeWindowFromPeek(hWnd);
         }

--- a/src/ManagedShell.WindowsTasks/ApplicationWindow.cs
+++ b/src/ManagedShell.WindowsTasks/ApplicationWindow.cs
@@ -313,6 +313,7 @@ namespace ManagedShell.WindowsTasks
             {
                 if (_hMonitor != value)
                 {
+                    ShellLogger.Debug($"ApplicationWindow: Monitor changed for {Handle} ({Title})");
                     _hMonitor = value;
                     OnPropertyChanged("HMonitor");
                 }

--- a/src/ManagedShell.WindowsTasks/ApplicationWindow.cs
+++ b/src/ManagedShell.WindowsTasks/ApplicationWindow.cs
@@ -313,7 +313,10 @@ namespace ManagedShell.WindowsTasks
             {
                 if (_hMonitor != value)
                 {
-                    ShellLogger.Debug($"ApplicationWindow: Monitor changed for {Handle} ({Title})");
+                    if (_hMonitor != IntPtr.Zero)
+                    {
+                        ShellLogger.Debug($"ApplicationWindow: Monitor changed for {Handle} ({Title})");
+                    }
                     _hMonitor = value;
                     OnPropertyChanged("HMonitor");
                 }

--- a/src/ManagedShell.WindowsTasks/TasksService.cs
+++ b/src/ManagedShell.WindowsTasks/TasksService.cs
@@ -451,7 +451,6 @@ namespace ManagedShell.WindowsTasks
                                 {
                                     ApplicationWindow win = Windows.First(wnd => wnd.Handle == msgCopy.LParam);
                                     win.SetMonitor();
-                                    ShellLogger.Debug($"TasksService: Monitor changed for {win.Handle} ({win.Title})");
 
                                     WindowEventArgs args = new WindowEventArgs
                                     {


### PR DESCRIPTION
- Removed the ShowInTaskbar=false from AppBarWindow because all it does is creates a hidden owner window and removes the APPWINDOW style. We already have the TOOLWINDOW style so we don't need an owner to be hidden from the taskbar. Enhanced the helper that sets TOOLWINDOW to also remove APPWINDOW.
- Removed a lot of duplication across AppBarManager and AppBarWindow, mostly around sizing/positioning logic.
- Added a cache of the current window rect to AppBarWindow so that it doesn't have to be fetched as often.
- More consistently use pixels instead of performing math on WPF's points-based size/position values
- Removed the timer-based AppBar positioning hacks in favor of reacting to unexpected WM_WINDOWPOSCHANGED messages instead. Whenever we intentionally update our position, we set a flag, so we only react when something else is doing it, which prevents creating a loop here.
- Added a workaround for [this WPF bug](https://github.com/dotnet/wpf/issues/7561)
- Fixed a few bugs with mixed DPI.
- Add virtual methods to AppBarWindow that shells can use to modify full screen event handling.