### PR TITLE
Ignore monitor cache when using TasksService events

### DIFF
--- a/src/ManagedShell.WindowsTasks/ApplicationWindow.cs
+++ b/src/ManagedShell.WindowsTasks/ApplicationWindow.cs
@@ -301,8 +301,9 @@ namespace ManagedShell.WindowsTasks
         {
             get
             {
-                if (_hMonitor == IntPtr.Zero)
+                if (_hMonitor == IntPtr.Zero || EnvironmentHelper.IsWindows8OrBetter)
                 {
+                    // Ignore the cache on Windows 8+, as it may be wrong.
                     SetMonitor();
                 }
 


### PR DESCRIPTION
On Windows 8 and newer, as of #123 we use the shell hook messages sent to us when a window moves to another monitor, instead of the global window move event hook that we use on Windows 7.

However, one limitation is that this tells us when the window moves to another monitor, but not necessarily when the monitor it is on is removed. When that happens, the cached HMonitor becomes incorrect.

When the system's displays change, shells that use this value are going to have to handle the display change events anyway to add/remove taskbars, so they will naturally fetch HMonitor from ApplicationWindow.

By ignoring the cached value in this scenario, we always end up with the correct value when it is needed. We still keep the cache around so that we can avoid triggering PropertyChanged events when HMonitor doesn't change.