### PR TITLE
Remove Cairo-specific code

### DIFF
--- a/src/ManagedShell.AppBar/AppBarEventArgs.cs
+++ b/src/ManagedShell.AppBar/AppBarEventArgs.cs
@@ -1,9 +1,0 @@
-﻿using System;
-
-namespace ManagedShell.AppBar
-{
-    public class AppBarEventArgs : EventArgs
-    {
-        public AppBarEventReason Reason;
-    }
-}

--- a/src/ManagedShell.AppBar/AppBarEventReason.cs
+++ b/src/ManagedShell.AppBar/AppBarEventReason.cs
@@ -1,8 +1,0 @@
-﻿namespace ManagedShell.AppBar
-{
-    public enum AppBarEventReason
-    {
-        MouseEnter,
-        MouseLeave
-    }
-}

--- a/src/ManagedShell.AppBar/AppBarManager.cs
+++ b/src/ManagedShell.AppBar/AppBarManager.cs
@@ -19,7 +19,6 @@ namespace ManagedShell.AppBar
 
         public List<AppBarWindow> AppBars { get; } = new List<AppBarWindow>();
         public List<AppBarWindow> AutoHideBars { get; } = new List<AppBarWindow>();
-        public EventHandler<AppBarEventArgs> AppBarEvent;
 
         public AppBarManager(ExplorerHelper explorerHelper)
         {
@@ -35,12 +34,6 @@ namespace ManagedShell.AppBar
             {
                 window.AllowClose = true;
             }
-        }
-
-        public void NotifyAppBarEvent(AppBarWindow sender, AppBarEventReason reason)
-        {
-            AppBarEventArgs args = new AppBarEventArgs { Reason = reason };
-            AppBarEvent?.Invoke(sender, args);
         }
 
         private IntPtr appBarMessageDelegate(APPBARMSGDATAV3 amd, ref bool handled)

--- a/src/ManagedShell.AppBar/AppBarWindow.cs
+++ b/src/ManagedShell.AppBar/AppBarWindow.cs
@@ -565,11 +565,6 @@ namespace ManagedShell.AppBar
                 ProcessScreenChange(ScreenSetupReason.DeviceChange);
                 handled = true;
             }
-            else if (msg == (int)NativeMethods.WM.DWMCOMPOSITIONCHANGED)
-            {
-                ProcessScreenChange(ScreenSetupReason.DwmChange);
-                handled = true;
-            }
             
             return IntPtr.Zero;
         }

--- a/src/ManagedShell.AppBar/ScreenSetupReason.cs
+++ b/src/ManagedShell.AppBar/ScreenSetupReason.cs
@@ -4,9 +4,6 @@
     {
         DeviceChange,
         DisplayChange,
-        DpiChange,
-        DwmChange,
-        FirstRun,
-        Reconciliation
+        DpiChange
     }
 }


### PR DESCRIPTION
Removes Cairo-specific functionality and enum values that shouldn't be in ManagedShell. They will be re-added as part of Cairo instead.