### PR TITLE
Fix closing task not correctly coming to foreground

### DIFF
--- a/src/ManagedShell.WindowsTasks/ApplicationWindow.cs
+++ b/src/ManagedShell.WindowsTasks/ApplicationWindow.cs
@@ -700,6 +700,7 @@ namespace ManagedShell.WindowsTasks
 
         internal IntPtr DoClose()
         {
+            makeForeground();
             IntPtr retval = IntPtr.Zero;
             NativeMethods.SendMessageTimeout(Handle, (int)NativeMethods.WM.SYSCOMMAND, NativeMethods.SC_CLOSE, 0, 2, 200, ref retval);
 


### PR DESCRIPTION
Set the window as foreground before closing so that any prompts for saving data, etc, are not hidden behind other windows. Matches explorer behavior.