### PR TITLE
Update SoundHelper

### DIFF
--- a/src/ManagedShell.Common/Helpers/SoundHelper.cs
+++ b/src/ManagedShell.Common/Helpers/SoundHelper.cs
@@ -28,7 +28,7 @@ namespace ManagedShell.Common.Helpers
                 {
                     if (key == null)
                     {
-                        ShellLogger.Error($"SoundHelper: Unable to find sound {name} for app {app}");
+                        ShellLogger.Debug($"SoundHelper: Unable to find sound {name} for app {app}");
                         return false;
                     }
 
@@ -36,7 +36,7 @@ namespace ManagedShell.Common.Helpers
                     {
                         if (string.IsNullOrEmpty(soundFileName))
                         {
-                            ShellLogger.Error($"SoundHelper: Missing file for sound {name} for app {app}");
+                            ShellLogger.Debug($"SoundHelper: Missing file for sound {name} for app {app}");
                             return false;
                         }
 
@@ -44,14 +44,14 @@ namespace ManagedShell.Common.Helpers
                     }
                     else
                     {
-                        ShellLogger.Error($"SoundHelper: Missing file for sound {name} for app {app}");
+                        ShellLogger.Debug($"SoundHelper: Missing file for sound {name} for app {app}");
                         return false;
                     }
                 }
             }
             catch (Exception e)
             {
-                ShellLogger.Error($"SoundHelper: Unable to play sound {name} for app {app}: {e.Message}");
+                ShellLogger.Debug($"SoundHelper: Unable to play sound {name} for app {app}: {e.Message}");
                 return false;
             }
         }

--- a/src/ManagedShell.Common/Helpers/SoundHelper.cs
+++ b/src/ManagedShell.Common/Helpers/SoundHelper.cs
@@ -9,20 +9,94 @@ namespace ManagedShell.Common.Helpers
     {
         private const string SYSTEM_SOUND_ROOT_KEY = @"AppEvents\Schemes\Apps";
 
+        /// <summary>
+        /// Flag values for playing the sound.
+        /// </summary>
         [Flags]
-        private enum PlaySoundFlags
+        public enum SND : uint
         {
-            SND_ASYNC = 0x00000001,
-            SND_NODEFAULT = 0x00000002,
-            SND_ALIAS = 0x00010000,
-            SND_FILENAME = 0x00020000,
-            SND_SYSTEM = 0x00200000,
+            /// <summary>
+            /// The sound is played synchronously; PlaySound returns after the sound event completes (default behavior).
+            /// </summary>
+            SYNC = 0x0000,
+
+            /// <summary>
+            /// The sound is played asynchronously; PlaySound returns immediately after initiating the sound.
+            /// To stop an asynchronously played sound, call PlaySound with pszSound set to NULL.
+            /// </summary>
+            ASYNC = 0x00000001,
+
+            /// <summary>
+            /// No default sound event is used. If the sound is not found, PlaySound returns without playing a sound.
+            /// </summary>
+            NODEFAULT = 0x00000002,
+
+            /// <summary>
+            /// The pszSound parameter points to a sound loaded in memory.
+            /// </summary>
+            MEMORY = 0x00000004,
+
+            /// <summary>
+            /// The sound plays repeatedly until PlaySound is called with pszSound set to NULL.
+            /// Use the ASYNC flag with LOOP.
+            /// </summary>
+            LOOP = 0x00000008,
+
+            /// <summary>
+            /// The specified sound event will yield to another sound event already playing in the same process.
+            /// If the required resource is busy, the function returns immediately without playing the sound.
+            /// </summary>
+            NOSTOP = 0x00000010,
+
+            /// <summary>
+            /// The pszSound parameter is a system-event alias from the registry or WIN.INI file.
+            /// Do not use with FILENAME or RESOURCE.
+            /// </summary>
+            ALIAS = 0x00010000,
+
+            /// <summary>
+            /// The pszSound parameter is a predefined identifier for a system-event alias.
+            /// </summary>
+            ALIAS_ID = 0x00110000,
+
+            /// <summary>
+            /// The pszSound parameter is a file name. If the file is not found, the default sound is played unless NODEFAULT is set.
+            /// </summary>
+            FILENAME = 0x00020000,
+
+            /// <summary>
+            /// The pszSound parameter is a resource identifier; hmod must identify the instance that contains the resource.
+            /// </summary>
+            RESOURCE = 0x00040004,
+
+            /// <summary>
+            /// The pszSound parameter is an application-specific alias in the registry.
+            /// Can be combined with ALIAS or ALIAS_ID to specify an application-defined sound alias.
+            /// </summary>
+            APPLICATION = 0x00000080,
+
+            /// <summary>
+            /// Requires Windows Vista or later. If set, triggers a SoundSentry event when the sound is played,
+            /// providing a visual cue for accessibility.
+            /// </summary>
+            SENTRY = 0x00080000,
+
+            /// <summary>
+            /// Treats the sound as a ring from a communications app.
+            /// </summary>
+            RING = 0x00100000,
+
+            /// <summary>
+            /// Requires Windows Vista or later. If set, the sound is assigned to the audio session for system notification sounds,
+            /// allowing control via the system volume slider. Otherwise, it is assigned to the application's default audio session.
+            /// </summary>
+            SYSTEM = 0x00200000,
         }
 
-        private const PlaySoundFlags DEFAULT_SYSTEM_SOUND_FLAGS = PlaySoundFlags.SND_ASYNC | PlaySoundFlags.SND_NODEFAULT | PlaySoundFlags.SND_SYSTEM;
+        private const SND DEFAULT_SYSTEM_SOUND_FLAGS = SND.ASYNC | SND.NODEFAULT | SND.SYSTEM;
 
         [DllImport("winmm.dll", SetLastError = true, CharSet = CharSet.Auto)]
-        private static extern bool PlaySound(string pszSound, IntPtr hmod, PlaySoundFlags soundFlags);
+        public static extern bool PlaySound(string pszSound, IntPtr hmod, SND soundFlags);
 
         /// <summary>
         /// Plays the specified system sound using the audio session for system notification sounds.
@@ -47,7 +121,7 @@ namespace ManagedShell.Common.Helpers
                     return false;
                 }
 
-                return PlaySound(soundFileName, IntPtr.Zero, DEFAULT_SYSTEM_SOUND_FLAGS | PlaySoundFlags.SND_FILENAME);
+                return PlaySound(soundFileName, IntPtr.Zero, DEFAULT_SYSTEM_SOUND_FLAGS | SND.FILENAME);
             }
             catch (Exception e)
             {
@@ -60,15 +134,16 @@ namespace ManagedShell.Common.Helpers
         /// Plays the specified system sound using the audio session for system notification sounds.
         /// </summary>
         /// <param name="alias">The name of the system sound for ".Default" to play.</param>
-        public static void PlaySystemSound(string alias)
+        public static bool PlaySystemSound(string alias)
         {
             try
             {
-                PlaySound(alias, IntPtr.Zero, DEFAULT_SYSTEM_SOUND_FLAGS | PlaySoundFlags.SND_ALIAS);
+                return PlaySound(alias, IntPtr.Zero, DEFAULT_SYSTEM_SOUND_FLAGS | SND.ALIAS);
             }
             catch (Exception e)
             {
-                ShellLogger.Error($"SoundHelper: Unable to play sound {alias}: {e.Message}");
+                ShellLogger.Debug($"SoundHelper: Unable to play sound {alias}: {e.Message}");
+                return false;
             }
         }
 
@@ -82,7 +157,7 @@ namespace ManagedShell.Common.Helpers
             if (EnvironmentHelper.IsWindows8OrBetter)
             {
                 // Toast notification sound.
-                if (!PlaySystemSound(".Default", "Notification.Default"))
+                if (!PlaySystemSound("Notification.Default"))
                     PlayXPNotificationSound();
             }
             else

--- a/src/ManagedShell.Common/Helpers/SoundHelper.cs
+++ b/src/ManagedShell.Common/Helpers/SoundHelper.cs
@@ -8,12 +8,21 @@ namespace ManagedShell.Common.Helpers
     public class SoundHelper
     {
         private const string SYSTEM_SOUND_ROOT_KEY = @"AppEvents\Schemes\Apps";
-        private const int SND_FILENAME = 0x00020000;
-        private const int SND_ASYNC = 0x0001;
-        private const long SND_SYSTEM = 0x00200000L;
+
+        [Flags]
+        private enum PlaySoundFlags
+        {
+            SND_ASYNC = 0x00000001,
+            SND_NODEFAULT = 0x00000002,
+            SND_ALIAS = 0x00010000,
+            SND_FILENAME = 0x00020000,
+            SND_SYSTEM = 0x00200000,
+        }
+
+        private const PlaySoundFlags DEFAULT_SYSTEM_SOUND_FLAGS = PlaySoundFlags.SND_ASYNC | PlaySoundFlags.SND_NODEFAULT | PlaySoundFlags.SND_SYSTEM;
 
         [DllImport("winmm.dll", SetLastError = true, CharSet = CharSet.Auto)]
-        private static extern bool PlaySound(string pszSound, IntPtr hmod, uint fdwSound);
+        private static extern bool PlaySound(string pszSound, IntPtr hmod, PlaySoundFlags soundFlags);
 
         /// <summary>
         /// Plays the specified system sound using the audio session for system notification sounds.
@@ -24,30 +33,21 @@ namespace ManagedShell.Common.Helpers
         {
             try
             {
-                using (RegistryKey key = Registry.CurrentUser.OpenSubKey($"{SYSTEM_SOUND_ROOT_KEY}\\{app}\\{name}\\.Current"))
+                using var key = Registry.CurrentUser.OpenSubKey($@"{SYSTEM_SOUND_ROOT_KEY}\{app}\{name}\.Current");
+                if (key == null)
                 {
-                    if (key == null)
-                    {
-                        ShellLogger.Debug($"SoundHelper: Unable to find sound {name} for app {app}");
-                        return false;
-                    }
-
-                    if (key.GetValue(null) is string soundFileName)
-                    {
-                        if (string.IsNullOrEmpty(soundFileName))
-                        {
-                            ShellLogger.Debug($"SoundHelper: Missing file for sound {name} for app {app}");
-                            return false;
-                        }
-
-                        return PlaySound(soundFileName, IntPtr.Zero, (uint)(SND_ASYNC | SND_FILENAME | SND_SYSTEM));
-                    }
-                    else
-                    {
-                        ShellLogger.Debug($"SoundHelper: Missing file for sound {name} for app {app}");
-                        return false;
-                    }
+                    ShellLogger.Error($"SoundHelper: Unable to find sound {name} for app {app}");
+                    return false;
                 }
+
+                var soundFileName = key.GetValue(null) as string;
+                if (string.IsNullOrEmpty(soundFileName))
+                {
+                    ShellLogger.Error($"SoundHelper: Missing file for sound {name} for app {app}");
+                    return false;
+                }
+
+                return PlaySound(soundFileName, IntPtr.Zero, DEFAULT_SYSTEM_SOUND_FLAGS | PlaySoundFlags.SND_FILENAME);
             }
             catch (Exception e)
             {
@@ -57,29 +57,43 @@ namespace ManagedShell.Common.Helpers
         }
 
         /// <summary>
+        /// Plays the specified system sound using the audio session for system notification sounds.
+        /// </summary>
+        /// <param name="alias">The name of the system sound for ".Default" to play.</param>
+        public static void PlaySystemSound(string alias)
+        {
+            try
+            {
+                PlaySound(alias, IntPtr.Zero, DEFAULT_SYSTEM_SOUND_FLAGS | PlaySoundFlags.SND_ALIAS);
+            }
+            catch (Exception e)
+            {
+                ShellLogger.Error($"SoundHelper: Unable to play sound {alias}: {e.Message}");
+            }
+        }
+
+        /// <summary>
         /// Plays the system notification sound.
         /// </summary>
         public static void PlayNotificationSound()
         {
             // System default sound for the classic notification balloon.
-            if (!PlaySystemSound("Explorer", "SystemNotification"))
+            if (PlaySystemSound("Explorer", "SystemNotification")) return;
+            if (EnvironmentHelper.IsWindows8OrBetter)
             {
-                if (EnvironmentHelper.IsWindows8OrBetter)
-                {
-                    // Toast notification sound.
-                    if (!PlaySystemSound(".Default", "Notification.Default"))
-                        PlayXPNotificationSound();
-                }
-                else
-                {
+                // Toast notification sound.
+                if (!PlaySystemSound(".Default", "Notification.Default"))
                     PlayXPNotificationSound();
-                }
+            }
+            else
+            {
+                PlayXPNotificationSound();
             }
         }
 
-        public static bool PlayXPNotificationSound()
+        public static void PlayXPNotificationSound()
         {
-            return PlaySystemSound(".Default", "SystemNotification");
+            PlaySystemSound("SystemNotification");
         }
     }
 }

--- a/src/ManagedShell.Common/Helpers/SoundHelper.cs
+++ b/src/ManagedShell.Common/Helpers/SoundHelper.cs
@@ -36,14 +36,14 @@ namespace ManagedShell.Common.Helpers
                 using var key = Registry.CurrentUser.OpenSubKey($@"{SYSTEM_SOUND_ROOT_KEY}\{app}\{name}\.Current");
                 if (key == null)
                 {
-                    ShellLogger.Error($"SoundHelper: Unable to find sound {name} for app {app}");
+                    ShellLogger.Debug($"SoundHelper: Unable to find sound {name} for app {app}");
                     return false;
                 }
 
                 var soundFileName = key.GetValue(null) as string;
                 if (string.IsNullOrEmpty(soundFileName))
                 {
-                    ShellLogger.Error($"SoundHelper: Missing file for sound {name} for app {app}");
+                    ShellLogger.Debug($"SoundHelper: Missing file for sound {name} for app {app}");
                     return false;
                 }
 

--- a/src/ManagedShell.Common/ManagedShell.Common.csproj
+++ b/src/ManagedShell.Common/ManagedShell.Common.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>netcoreapp3.1;net471;net6.0-windows</TargetFrameworks>
     <UseWindowsForms>true</UseWindowsForms>
     <UseWPF>true</UseWPF>
+    <LangVersion>12</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
* Used `SND` enumeration with documentation for sound flag values.
* Changed error logging to debug logging for missing sound files or registry keys, aligning with a less intrusive logging approach (the .log file was sometimes modified just after playing a notification before this).
* Added a new `PlaySystemSound(string alias)` method to play system sounds by alias.
* Upgraded `LangVersion` to 12 for `ManagedShell.Common`: I wrote most of the code on November 7, 2022, and I'm surprised that the project is still using an old language version.