### PR TITLE
Fix AppBarManager.GetWorkArea

### DIFF
--- a/.github/workflows/managedshell.yml
+++ b/.github/workflows/managedshell.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         buildconfig: [ Release ]
 
-    runs-on: windows-latest
+    runs-on: windows-2022
 
     env:
       project: src\ManagedShell\ManagedShell.csproj

--- a/src/ManagedShell.AppBar/AppBarManager.cs
+++ b/src/ManagedShell.AppBar/AppBarManager.cs
@@ -19,6 +19,7 @@ namespace ManagedShell.AppBar
 
         public List<AppBarWindow> AppBars { get; } = new List<AppBarWindow>();
         public List<AppBarWindow> AutoHideBars { get; } = new List<AppBarWindow>();
+        public List<AppBarWindow> OverlappingBars { get; } = new List<AppBarWindow>();
 
         public AppBarManager(ExplorerHelper explorerHelper)
         {
@@ -213,6 +214,26 @@ namespace ManagedShell.AppBar
             AutoHideBars.Remove(window);
         }
 
+        public void RegisterOverlappingBar(AppBarWindow window)
+        {
+            if (OverlappingBars.Contains(window))
+            {
+                return;
+            }
+
+            OverlappingBars.Add(window);
+        }
+
+        public void UnregisterOverlappingBar(AppBarWindow window)
+        {
+            if (!OverlappingBars.Contains(window))
+            {
+                return;
+            }
+
+            OverlappingBars.Remove(window);
+        }
+
         public int RegisterBar(AppBarWindow abWindow)
         {
             lock (appBarLock)
@@ -405,6 +426,56 @@ namespace ManagedShell.AppBar
                         case AppBarEdge.Top:
                             topEdgeWindowHeight += window.WindowRect.Height;
                             break;
+                    }
+                }
+            }
+
+            if (!enabledBarsOnly)
+            {
+                foreach (var window in AutoHideBars)
+                {
+                    if (window.Screen.DeviceName == screen.DeviceName &&
+                        window.Handle != hWndIgnore &&
+                        (window.RequiresScreenEdge || !edgeBarsOnly))
+                    {
+                        switch (window.AppBarEdge)
+                        {
+                            case AppBarEdge.Left:
+                                leftEdgeWindowWidth += window.WindowRect.Width;
+                                break;
+                            case AppBarEdge.Right:
+                                rightEdgeWindowWidth += window.WindowRect.Width;
+                                break;
+                            case AppBarEdge.Bottom:
+                                bottomEdgeWindowHeight += window.WindowRect.Height;
+                                break;
+                            case AppBarEdge.Top:
+                                topEdgeWindowHeight += window.WindowRect.Height;
+                                break;
+                        }
+                    }
+                }
+                foreach (var window in OverlappingBars)
+                {
+                    if (window.Screen.DeviceName == screen.DeviceName &&
+                        window.Handle != hWndIgnore &&
+                        (window.RequiresScreenEdge || !edgeBarsOnly))
+                    {
+                        switch (window.AppBarEdge)
+                        {
+                            case AppBarEdge.Left:
+                                leftEdgeWindowWidth += window.WindowRect.Width;
+                                break;
+                            case AppBarEdge.Right:
+                                rightEdgeWindowWidth += window.WindowRect.Width;
+                                break;
+                            case AppBarEdge.Bottom:
+                                bottomEdgeWindowHeight += window.WindowRect.Height;
+                                break;
+                            case AppBarEdge.Top:
+                                topEdgeWindowHeight += window.WindowRect.Height;
+                                break;
+                        }
                     }
                 }
             }

--- a/src/ManagedShell.AppBar/AppBarWindow.cs
+++ b/src/ManagedShell.AppBar/AppBarWindow.cs
@@ -194,6 +194,15 @@ namespace ManagedShell.AppBar
                     _appBarManager.UnregisterAutoHideBar(this);
                     AnimateAutoHide(false, true);
                 }
+
+                if (AppBarMode == AppBarMode.None)
+                {
+                    _appBarManager.RegisterOverlappingBar(this);
+                }
+                else
+                {
+                    _appBarManager.UnregisterOverlappingBar(this);
+                }
             }
         }
 
@@ -294,6 +303,10 @@ namespace ManagedShell.AppBar
             {
                 _appBarManager.RegisterAutoHideBar(this);
             }
+            else
+            {
+                _appBarManager.RegisterOverlappingBar(this);
+            }
 
             // hide from alt-tab etc
             WindowHelper.HideWindowFromTasks(Handle);
@@ -363,6 +376,7 @@ namespace ManagedShell.AppBar
             {
                 UnregisterAppBar();
                 _appBarManager.UnregisterAutoHideBar(this);
+                _appBarManager.UnregisterOverlappingBar(this);
                 AutoHideElement?.RenderTransform?.BeginAnimation(TranslateTransform.YProperty, null);
                 AutoHideElement?.RenderTransform?.BeginAnimation(TranslateTransform.XProperty, null);
 

--- a/src/ManagedShell.UWPInterop/ManagedShell.UWPInterop.csproj
+++ b/src/ManagedShell.UWPInterop/ManagedShell.UWPInterop.csproj
@@ -42,6 +42,7 @@
 			Windows.Globalization.DayOfWeek;
 			Windows.Management.Deployment;
 			Windows.Storage;
+			Windows.Storage.Provider.FileUpdateStatus;
 			Windows.System.IUser;
 			Windows.System.ProcessorArchitecture;
 			Windows.System.User;
@@ -50,6 +51,7 @@
 			Windows.Foundation.Diagnostics;
 			Windows.Foundation.PropertyType;
 			Windows.Storage.BulkAccess;
+			Windows.Storage.Provider;
 		</CsWinRTExcludes>
 	</PropertyGroup>
 


### PR DESCRIPTION
This never worked as originally intended with `enabledBarsOnly=false`, because only "enabled" AppBars were tracked in the first place. Oops!