### PR TITLE
Fix leak when referencing SearchHelper.Results

### DIFF
--- a/src/ManagedShell.Common/Helpers/SearchHelper.cs
+++ b/src/ManagedShell.Common/Helpers/SearchHelper.cs
@@ -25,6 +25,7 @@ namespace ManagedShell.Common.Helpers
         static SearchHelper()
         {
             m_results = new ThreadSafeObservableCollection<SearchResult>();
+            m_resultsReadOnly = new ReadOnlyObservableCollection<SearchResult>(m_results);
         }
 
         public static readonly DependencyProperty SearchTextProperty = DependencyProperty.Register("SearchText",
@@ -193,10 +194,11 @@ namespace ManagedShell.Common.Helpers
         }
 
         static ThreadSafeObservableCollection<SearchResult> m_results;
+        static ReadOnlyObservableCollection<SearchResult> m_resultsReadOnly;
 
         public ReadOnlyObservableCollection<SearchResult> Results
         {
-            get { return new ReadOnlyObservableCollection<SearchResult>(m_results); }
+            get { return m_resultsReadOnly; }
         }
     }
 }


### PR DESCRIPTION
Since every access created a new collection, event handlers created by e.g. bindings weren't removable.