### PR TITLE
Allow hide taskbar retrying

### DIFF
--- a/src/ManagedShell.AppBar/ExplorerHelper.cs
+++ b/src/ManagedShell.AppBar/ExplorerHelper.cs
@@ -24,7 +24,7 @@ namespace ManagedShell.AppBar
 
             set
             {
-                if (value != _hideExplorerTaskbar)
+                if (value != _hideExplorerTaskbar && !EnvironmentHelper.IsAppRunningAsShell)
                 {
                     _hideExplorerTaskbar = value;
 
@@ -124,18 +124,15 @@ namespace ManagedShell.AppBar
 
         private void HideTaskbar()
         {
-            if (!EnvironmentHelper.IsAppRunningAsShell)
+            if (startupTaskbarState == null)
             {
-                if (startupTaskbarState == null)
-                {
-                    startupTaskbarState = GetTaskbarState();
-                }
+                startupTaskbarState = GetTaskbarState();
+            }
 
-                if (HideExplorerTaskbar)
-                {
-                    DoHideTaskbar();
-                    taskbarMonitor.Start();
-                }
+            if (HideExplorerTaskbar)
+            {
+                DoHideTaskbar();
+                taskbarMonitor.Start();
             }
         }
 
@@ -147,12 +144,9 @@ namespace ManagedShell.AppBar
 
         private void ShowTaskbar()
         {
-            if (!EnvironmentHelper.IsAppRunningAsShell)
-            {
-                SetTaskbarState(startupTaskbarState ?? ABState.Default);
-                SetTaskbarVisibility((int)SetWindowPosFlags.SWP_SHOWWINDOW);
-                taskbarMonitor.Stop();
-            }
+            SetTaskbarState(startupTaskbarState ?? ABState.Default);
+            SetTaskbarVisibility((int)SetWindowPosFlags.SWP_SHOWWINDOW);
+            taskbarMonitor.Stop();
         }
 
         private void SetupTaskbarMonitor()


### PR DESCRIPTION
Some apps such as WindowBlinds may cause delays in the Shell process. Not sure how exactly. But this can cause initial hide taskbar calls to fail as the app will be determined to be running as shell. Later on when the shell process has begun we want to retry this, however it is blocked since we have already updated the internal value. So only update the internal value if we actually start the taskbar hiding process (not running as shell).

This is only apparent it seems when running RetroBar/ManagedShell from Task Scheduler for faster startup. Related to: https://github.com/dremin/RetroBar/issues/440

There will be a corresponding fix PR in RetroBar as well