### PR TITLE
Use Get/SetWindowLongPtr on 64-bit systems

### DIFF
--- a/src/ManagedShell.AppBar/FullScreenHelper.cs
+++ b/src/ManagedShell.AppBar/FullScreenHelper.cs
@@ -141,7 +141,7 @@ namespace ManagedShell.AppBar
                     else
                     {
                         // Still full screen but no longer active
-                        if (((int)GetWindowLongPtr(hWnd, (int)WindowLongFlags.GWL_EXSTYLE) & (int)ExtendedWindowStyles.WS_EX_TOPMOST) == (int)ExtendedWindowStyles.WS_EX_TOPMOST)
+                        if (((int)GetWindowLongPtr(hWnd, WindowLongFlags.GWL_EXSTYLE) & (int)ExtendedWindowStyles.WS_EX_TOPMOST) == (int)ExtendedWindowStyles.WS_EX_TOPMOST)
                         {
                             // If the new foreground window is a topmost window, don't consider this full-screen app inactive
                             continue;
@@ -265,7 +265,7 @@ namespace ManagedShell.AppBar
 
         private Rect GetEffectiveWindowRect(IntPtr hWnd)
         {
-            int style = (int)GetWindowLongPtr(hWnd, (int)WindowLongFlags.GWL_STYLE);
+            int style = (int)GetWindowLongPtr(hWnd, WindowLongFlags.GWL_STYLE);
             Rect rect;
 
             if ((((int)WindowStyles.WS_CAPTION | (int)WindowStyles.WS_THICKFRAME) & style) == ((int)WindowStyles.WS_CAPTION | (int)WindowStyles.WS_THICKFRAME) ||

--- a/src/ManagedShell.AppBar/FullScreenHelper.cs
+++ b/src/ManagedShell.AppBar/FullScreenHelper.cs
@@ -141,7 +141,7 @@ namespace ManagedShell.AppBar
                     else
                     {
                         // Still full screen but no longer active
-                        if (((int)GetWindowLongPtr(hWnd, GWL_EXSTYLE) & (int)ExtendedWindowStyles.WS_EX_TOPMOST) == (int)ExtendedWindowStyles.WS_EX_TOPMOST)
+                        if (((int)GetWindowLongPtr(hWnd, (int)WindowLongFlags.GWL_EXSTYLE) & (int)ExtendedWindowStyles.WS_EX_TOPMOST) == (int)ExtendedWindowStyles.WS_EX_TOPMOST)
                         {
                             // If the new foreground window is a topmost window, don't consider this full-screen app inactive
                             continue;
@@ -265,7 +265,7 @@ namespace ManagedShell.AppBar
 
         private Rect GetEffectiveWindowRect(IntPtr hWnd)
         {
-            int style = (int)GetWindowLongPtr(hWnd, GWL_STYLE);
+            int style = (int)GetWindowLongPtr(hWnd, (int)WindowLongFlags.GWL_STYLE);
             Rect rect;
 
             if ((((int)WindowStyles.WS_CAPTION | (int)WindowStyles.WS_THICKFRAME) & style) == ((int)WindowStyles.WS_CAPTION | (int)WindowStyles.WS_THICKFRAME) ||

--- a/src/ManagedShell.AppBar/FullScreenHelper.cs
+++ b/src/ManagedShell.AppBar/FullScreenHelper.cs
@@ -141,7 +141,7 @@ namespace ManagedShell.AppBar
                     else
                     {
                         // Still full screen but no longer active
-                        if ((GetWindowLong(hWnd, GWL_EXSTYLE) & (int)ExtendedWindowStyles.WS_EX_TOPMOST) == (int)ExtendedWindowStyles.WS_EX_TOPMOST)
+                        if (((int)GetWindowLongPtr(hWnd, GWL_EXSTYLE) & (int)ExtendedWindowStyles.WS_EX_TOPMOST) == (int)ExtendedWindowStyles.WS_EX_TOPMOST)
                         {
                             // If the new foreground window is a topmost window, don't consider this full-screen app inactive
                             continue;
@@ -265,7 +265,7 @@ namespace ManagedShell.AppBar
 
         private Rect GetEffectiveWindowRect(IntPtr hWnd)
         {
-            int style = GetWindowLong(hWnd, GWL_STYLE);
+            int style = (int)GetWindowLongPtr(hWnd, GWL_STYLE);
             Rect rect;
 
             if ((((int)WindowStyles.WS_CAPTION | (int)WindowStyles.WS_THICKFRAME) & style) == ((int)WindowStyles.WS_CAPTION | (int)WindowStyles.WS_THICKFRAME) ||

--- a/src/ManagedShell.Common/Helpers/WindowHelper.cs
+++ b/src/ManagedShell.Common/Helpers/WindowHelper.cs
@@ -103,7 +103,7 @@ namespace ManagedShell.Common.Helpers
         
         public static void HideWindowFromTasks(IntPtr hWnd)
         {
-            int style = (int)GetWindowLongPtr(hWnd, (int)WindowLongFlags.GWL_EXSTYLE) & ~(int)ExtendedWindowStyles.WS_EX_APPWINDOW;
+            int style = (int)GetWindowLongPtr(hWnd, WindowLongFlags.GWL_EXSTYLE) & ~(int)ExtendedWindowStyles.WS_EX_APPWINDOW;
             if (EnvironmentHelper.IsWindows11OrBetter)
             {
                 // If the window has a Hidden Window owner, set the owner as a tool window instead so that we still receive WM_DPICHANGED on Windows 11.
@@ -121,7 +121,7 @@ namespace ManagedShell.Common.Helpers
                     GetWindowText(hwndOwner, titleBuilder, TITLE_LENGTH + 1);
                     if (titleBuilder.ToString() == "Hidden Window")
                     {
-                        SetWindowLongPtr(hwndOwner, (int)WindowLongFlags.GWL_EXSTYLE, (IntPtr)((int)GetWindowLongPtr(hwndOwner, (int)WindowLongFlags.GWL_EXSTYLE) | (int)ExtendedWindowStyles.WS_EX_TOOLWINDOW));
+                        SetWindowLongPtr(hwndOwner, WindowLongFlags.GWL_EXSTYLE, (IntPtr)((int)GetWindowLongPtr(hwndOwner, WindowLongFlags.GWL_EXSTYLE) | (int)ExtendedWindowStyles.WS_EX_TOOLWINDOW));
                     }
                 }
             }
@@ -129,7 +129,7 @@ namespace ManagedShell.Common.Helpers
             {
                 style |= (int)ExtendedWindowStyles.WS_EX_TOOLWINDOW;
             }
-            SetWindowLongPtr(hWnd, (int)WindowLongFlags.GWL_EXSTYLE, (IntPtr)style);
+            SetWindowLongPtr(hWnd, WindowLongFlags.GWL_EXSTYLE, (IntPtr)style);
 
             ExcludeWindowFromPeek(hWnd);
         }

--- a/src/ManagedShell.Common/Helpers/WindowHelper.cs
+++ b/src/ManagedShell.Common/Helpers/WindowHelper.cs
@@ -103,7 +103,7 @@ namespace ManagedShell.Common.Helpers
         
         public static void HideWindowFromTasks(IntPtr hWnd)
         {
-            int style = (int)GetWindowLongPtr(hWnd, GWL_EXSTYLE) & ~(int)ExtendedWindowStyles.WS_EX_APPWINDOW;
+            int style = (int)GetWindowLongPtr(hWnd, (int)WindowLongFlags.GWL_EXSTYLE) & ~(int)ExtendedWindowStyles.WS_EX_APPWINDOW;
             if (EnvironmentHelper.IsWindows11OrBetter)
             {
                 // If the window has a Hidden Window owner, set the owner as a tool window instead so that we still receive WM_DPICHANGED on Windows 11.
@@ -121,7 +121,7 @@ namespace ManagedShell.Common.Helpers
                     GetWindowText(hwndOwner, titleBuilder, TITLE_LENGTH + 1);
                     if (titleBuilder.ToString() == "Hidden Window")
                     {
-                        SetWindowLongPtr(hwndOwner, GWL_EXSTYLE, (IntPtr)((int)GetWindowLongPtr(hwndOwner, GWL_EXSTYLE) | (int)ExtendedWindowStyles.WS_EX_TOOLWINDOW));
+                        SetWindowLongPtr(hwndOwner, (int)WindowLongFlags.GWL_EXSTYLE, (IntPtr)((int)GetWindowLongPtr(hwndOwner, (int)WindowLongFlags.GWL_EXSTYLE) | (int)ExtendedWindowStyles.WS_EX_TOOLWINDOW));
                     }
                 }
             }
@@ -129,7 +129,7 @@ namespace ManagedShell.Common.Helpers
             {
                 style |= (int)ExtendedWindowStyles.WS_EX_TOOLWINDOW;
             }
-            SetWindowLongPtr(hWnd, GWL_EXSTYLE, (IntPtr)style);
+            SetWindowLongPtr(hWnd, (int)WindowLongFlags.GWL_EXSTYLE, (IntPtr)style);
 
             ExcludeWindowFromPeek(hWnd);
         }

--- a/src/ManagedShell.Common/Helpers/WindowHelper.cs
+++ b/src/ManagedShell.Common/Helpers/WindowHelper.cs
@@ -103,7 +103,7 @@ namespace ManagedShell.Common.Helpers
         
         public static void HideWindowFromTasks(IntPtr hWnd)
         {
-            int style = GetWindowLong(hWnd, GWL_EXSTYLE) & ~(int)ExtendedWindowStyles.WS_EX_APPWINDOW;
+            int style = (int)GetWindowLongPtr(hWnd, GWL_EXSTYLE) & ~(int)ExtendedWindowStyles.WS_EX_APPWINDOW;
             if (EnvironmentHelper.IsWindows11OrBetter)
             {
                 // If the window has a Hidden Window owner, set the owner as a tool window instead so that we still receive WM_DPICHANGED on Windows 11.
@@ -121,7 +121,7 @@ namespace ManagedShell.Common.Helpers
                     GetWindowText(hwndOwner, titleBuilder, TITLE_LENGTH + 1);
                     if (titleBuilder.ToString() == "Hidden Window")
                     {
-                        SetWindowLong(hwndOwner, GWL_EXSTYLE, GetWindowLong(hwndOwner, GWL_EXSTYLE) | (int)ExtendedWindowStyles.WS_EX_TOOLWINDOW);
+                        SetWindowLongPtr(hwndOwner, GWL_EXSTYLE, (IntPtr)((int)GetWindowLongPtr(hwndOwner, GWL_EXSTYLE) | (int)ExtendedWindowStyles.WS_EX_TOOLWINDOW));
                     }
                 }
             }
@@ -129,7 +129,7 @@ namespace ManagedShell.Common.Helpers
             {
                 style |= (int)ExtendedWindowStyles.WS_EX_TOOLWINDOW;
             }
-            SetWindowLong(hWnd, GWL_EXSTYLE, style);
+            SetWindowLongPtr(hWnd, GWL_EXSTYLE, (IntPtr)style);
 
             ExcludeWindowFromPeek(hWnd);
         }

--- a/src/ManagedShell.Common/SupportingClasses/ShellWindow.cs
+++ b/src/ManagedShell.Common/SupportingClasses/ShellWindow.cs
@@ -24,8 +24,8 @@ namespace ManagedShell.Common.SupportingClasses
 
             CreateHandle(cp);
             MessageReceived += ShellWndProc;
-            NativeMethods.SetWindowLongPtr(Handle, NativeMethods.GWL_EXSTYLE, 
-                (IntPtr)((int)NativeMethods.GetWindowLongPtr(Handle, NativeMethods.GWL_EXSTYLE) & 
+            NativeMethods.SetWindowLongPtr(Handle, (int)NativeMethods.WindowLongFlags.GWL_EXSTYLE, 
+                (IntPtr)((int)NativeMethods.GetWindowLongPtr(Handle, (int)NativeMethods.WindowLongFlags.GWL_EXSTYLE) & 
                 ~(int)NativeMethods.ExtendedWindowStyles.WS_EX_NOACTIVATE));
 
             if (NativeMethods.SetShellWindow(Handle) == 1)

--- a/src/ManagedShell.Common/SupportingClasses/ShellWindow.cs
+++ b/src/ManagedShell.Common/SupportingClasses/ShellWindow.cs
@@ -24,9 +24,9 @@ namespace ManagedShell.Common.SupportingClasses
 
             CreateHandle(cp);
             MessageReceived += ShellWndProc;
-            NativeMethods.SetWindowLong(Handle, NativeMethods.GWL_EXSTYLE, 
-                NativeMethods.GetWindowLong(Handle, NativeMethods.GWL_EXSTYLE) & 
-                ~(int)NativeMethods.ExtendedWindowStyles.WS_EX_NOACTIVATE);
+            NativeMethods.SetWindowLongPtr(Handle, NativeMethods.GWL_EXSTYLE, 
+                (IntPtr)((int)NativeMethods.GetWindowLongPtr(Handle, NativeMethods.GWL_EXSTYLE) & 
+                ~(int)NativeMethods.ExtendedWindowStyles.WS_EX_NOACTIVATE));
 
             if (NativeMethods.SetShellWindow(Handle) == 1)
             {

--- a/src/ManagedShell.Common/SupportingClasses/ShellWindow.cs
+++ b/src/ManagedShell.Common/SupportingClasses/ShellWindow.cs
@@ -24,8 +24,8 @@ namespace ManagedShell.Common.SupportingClasses
 
             CreateHandle(cp);
             MessageReceived += ShellWndProc;
-            NativeMethods.SetWindowLongPtr(Handle, (int)NativeMethods.WindowLongFlags.GWL_EXSTYLE, 
-                (IntPtr)((int)NativeMethods.GetWindowLongPtr(Handle, (int)NativeMethods.WindowLongFlags.GWL_EXSTYLE) & 
+            NativeMethods.SetWindowLongPtr(Handle, NativeMethods.WindowLongFlags.GWL_EXSTYLE, 
+                (IntPtr)((int)NativeMethods.GetWindowLongPtr(Handle, NativeMethods.WindowLongFlags.GWL_EXSTYLE) & 
                 ~(int)NativeMethods.ExtendedWindowStyles.WS_EX_NOACTIVATE));
 
             if (NativeMethods.SetShellWindow(Handle) == 1)

--- a/src/ManagedShell.Interop/NativeMethods.User32.cs
+++ b/src/ManagedShell.Interop/NativeMethods.User32.cs
@@ -214,8 +214,20 @@ namespace ManagedShell.Interop
         }
 
         public const int MA_NOACTIVATE = 0x0003;
-        public const int GWL_STYLE = -16;
-        public const int GWL_EXSTYLE = -20;
+
+        public enum WindowLongFlags : int
+        {
+            GWL_EXSTYLE = -20,
+            GWLP_HINSTANCE = -6,
+            GWLP_HWNDPARENT = -8,
+            GWL_ID = -12,
+            GWL_STYLE = -16,
+            GWL_USERDATA = -21,
+            GWL_WNDPROC = -4,
+            DWLP_USER = 0x8,
+            DWLP_MSGRESULT = 0x0,
+            DWLP_DLGPROC = 0x4
+        }
 
         public const int HSHELL_HIGHBIT = 0x8000;
 

--- a/src/ManagedShell.Interop/NativeMethods.User32.cs
+++ b/src/ManagedShell.Interop/NativeMethods.User32.cs
@@ -267,7 +267,19 @@ namespace ManagedShell.Interop
         public delegate IntPtr WndProcDelegate(IntPtr hWnd, int msg, IntPtr wParam, IntPtr lParam);
 
         [DllImport(User32_DllName, SetLastError = true)]
-        public static extern int GetWindowLong(IntPtr hWnd, int nIndex);
+        private static extern int GetWindowLong(IntPtr hWnd, int nIndex);
+
+        [DllImport(User32_DllName, EntryPoint = "GetWindowLongPtr", SetLastError = true)]
+        private static extern IntPtr GetWindowLong64(IntPtr hWnd, int nIndex);
+
+        // This static method is required because Win32 does not support
+        // GetWindowLongPtr directly
+        public static IntPtr GetWindowLongPtr(IntPtr hWnd, int nIndex)
+        {
+            if (IntPtr.Size == 8)
+                return GetWindowLong64(hWnd, nIndex);
+            return (IntPtr)GetWindowLong(hWnd, nIndex);
+        }
 
         [return: MarshalAs(UnmanagedType.Bool)]
         [DllImport(User32_DllName, SetLastError = true)]
@@ -1704,7 +1716,19 @@ namespace ManagedShell.Interop
         public static extern bool IsWindowEnabled(IntPtr hWnd);
 
         [DllImport(User32_DllName)]
-        public static extern IntPtr SetWindowLong(IntPtr hWnd, int nIndex, int dwNewLong);
+        private static extern int SetWindowLong(IntPtr hWnd, int nIndex, int dwNewLong);
+
+        [DllImport(User32_DllName, EntryPoint = "SetWindowLongPtr")]
+        private static extern IntPtr SetWindowLong64(IntPtr hWnd, int nIndex, IntPtr dwNewLong);
+
+        // This static method is required because Win32 does not support
+        // SetWindowLongPtr directly
+        public static IntPtr SetWindowLongPtr(IntPtr hWnd, int nIndex, IntPtr dwNewLong)
+        {
+            if (IntPtr.Size == 8)
+                return SetWindowLong64(hWnd, nIndex, dwNewLong);
+            return (IntPtr)SetWindowLong(hWnd, nIndex, dwNewLong.ToInt32());
+        }
 
         [DllImport(User32_DllName, SetLastError = true)]
         public static extern uint GetWindowThreadProcessId(IntPtr hWnd, out uint lpdwProcessId);

--- a/src/ManagedShell.Interop/NativeMethods.User32.cs
+++ b/src/ManagedShell.Interop/NativeMethods.User32.cs
@@ -284,6 +284,11 @@ namespace ManagedShell.Interop
         [DllImport(User32_DllName, EntryPoint = "GetWindowLongPtr", SetLastError = true)]
         private static extern IntPtr GetWindowLong64(IntPtr hWnd, int nIndex);
 
+        public static IntPtr GetWindowLongPtr(IntPtr hWnd, WindowLongFlags nIndex)
+        {
+            return GetWindowLongPtr(hWnd, (int)nIndex);
+        }
+
         // This static method is required because Win32 does not support
         // GetWindowLongPtr directly
         public static IntPtr GetWindowLongPtr(IntPtr hWnd, int nIndex)
@@ -1732,6 +1737,11 @@ namespace ManagedShell.Interop
 
         [DllImport(User32_DllName, EntryPoint = "SetWindowLongPtr")]
         private static extern IntPtr SetWindowLong64(IntPtr hWnd, int nIndex, IntPtr dwNewLong);
+
+        public static IntPtr SetWindowLongPtr(IntPtr hWnd, WindowLongFlags nIndex, IntPtr dwNewLong)
+        {
+            return SetWindowLongPtr(hWnd, (int)nIndex, dwNewLong);
+        }
 
         // This static method is required because Win32 does not support
         // SetWindowLongPtr directly

--- a/src/ManagedShell.WindowsTasks/ApplicationWindow.cs
+++ b/src/ManagedShell.WindowsTasks/ApplicationWindow.cs
@@ -338,7 +338,7 @@ namespace ManagedShell.WindowsTasks
         {
             get
             {
-                return (int)NativeMethods.GetWindowLongPtr(Handle, (int)NativeMethods.WindowLongFlags.GWL_STYLE);
+                return (int)NativeMethods.GetWindowLongPtr(Handle, NativeMethods.WindowLongFlags.GWL_STYLE);
             }
         }
 
@@ -346,7 +346,7 @@ namespace ManagedShell.WindowsTasks
         {
             get
             {
-                return (int)NativeMethods.GetWindowLongPtr(Handle, (int)NativeMethods.WindowLongFlags.GWL_EXSTYLE);
+                return (int)NativeMethods.GetWindowLongPtr(Handle, NativeMethods.WindowLongFlags.GWL_EXSTYLE);
             }
         }
 

--- a/src/ManagedShell.WindowsTasks/ApplicationWindow.cs
+++ b/src/ManagedShell.WindowsTasks/ApplicationWindow.cs
@@ -338,7 +338,7 @@ namespace ManagedShell.WindowsTasks
         {
             get
             {
-                return NativeMethods.GetWindowLong(Handle, NativeMethods.GWL_STYLE);
+                return (int)NativeMethods.GetWindowLongPtr(Handle, NativeMethods.GWL_STYLE);
             }
         }
 
@@ -346,7 +346,7 @@ namespace ManagedShell.WindowsTasks
         {
             get
             {
-                return NativeMethods.GetWindowLong(Handle, NativeMethods.GWL_EXSTYLE);
+                return (int)NativeMethods.GetWindowLongPtr(Handle, NativeMethods.GWL_EXSTYLE);
             }
         }
 

--- a/src/ManagedShell.WindowsTasks/ApplicationWindow.cs
+++ b/src/ManagedShell.WindowsTasks/ApplicationWindow.cs
@@ -338,7 +338,7 @@ namespace ManagedShell.WindowsTasks
         {
             get
             {
-                return (int)NativeMethods.GetWindowLongPtr(Handle, NativeMethods.GWL_STYLE);
+                return (int)NativeMethods.GetWindowLongPtr(Handle, (int)NativeMethods.WindowLongFlags.GWL_STYLE);
             }
         }
 
@@ -346,7 +346,7 @@ namespace ManagedShell.WindowsTasks
         {
             get
             {
-                return (int)NativeMethods.GetWindowLongPtr(Handle, NativeMethods.GWL_EXSTYLE);
+                return (int)NativeMethods.GetWindowLongPtr(Handle, (int)NativeMethods.WindowLongFlags.GWL_EXSTYLE);
             }
         }
 

--- a/src/ManagedShell.WindowsTray/TrayService.cs
+++ b/src/ManagedShell.WindowsTray/TrayService.cs
@@ -239,8 +239,8 @@ namespace ManagedShell.WindowsTray
 
                     if ((wndPos.flags & SetWindowPosFlags.SWP_SHOWWINDOW) != 0)
                     {
-                        SetWindowLongPtr(HwndTray, (int)WindowLongFlags.GWL_STYLE,
-                            (IntPtr)((int)GetWindowLongPtr(HwndTray, (int)WindowLongFlags.GWL_STYLE) &
+                        SetWindowLongPtr(HwndTray, WindowLongFlags.GWL_STYLE,
+                            (IntPtr)((int)GetWindowLongPtr(HwndTray, WindowLongFlags.GWL_STYLE) &
                             ~(int)WindowStyles.WS_VISIBLE));
 
                         ShellLogger.Debug($"TrayService: {TrayWndClass} became visible; hiding");

--- a/src/ManagedShell.WindowsTray/TrayService.cs
+++ b/src/ManagedShell.WindowsTray/TrayService.cs
@@ -239,8 +239,8 @@ namespace ManagedShell.WindowsTray
 
                     if ((wndPos.flags & SetWindowPosFlags.SWP_SHOWWINDOW) != 0)
                     {
-                        SetWindowLongPtr(HwndTray, GWL_STYLE,
-                            (IntPtr)((int)GetWindowLongPtr(HwndTray, GWL_STYLE) &
+                        SetWindowLongPtr(HwndTray, (int)WindowLongFlags.GWL_STYLE,
+                            (IntPtr)((int)GetWindowLongPtr(HwndTray, (int)WindowLongFlags.GWL_STYLE) &
                             ~(int)WindowStyles.WS_VISIBLE));
 
                         ShellLogger.Debug($"TrayService: {TrayWndClass} became visible; hiding");

--- a/src/ManagedShell.WindowsTray/TrayService.cs
+++ b/src/ManagedShell.WindowsTray/TrayService.cs
@@ -239,9 +239,9 @@ namespace ManagedShell.WindowsTray
 
                     if ((wndPos.flags & SetWindowPosFlags.SWP_SHOWWINDOW) != 0)
                     {
-                        SetWindowLong(HwndTray, GWL_STYLE,
-                            GetWindowLong(HwndTray, GWL_STYLE) &
-                            ~(int)WindowStyles.WS_VISIBLE);
+                        SetWindowLongPtr(HwndTray, GWL_STYLE,
+                            (IntPtr)((int)GetWindowLongPtr(HwndTray, GWL_STYLE) &
+                            ~(int)WindowStyles.WS_VISIBLE));
 
                         ShellLogger.Debug($"TrayService: {TrayWndClass} became visible; hiding");
                     }


### PR DESCRIPTION
Per docs, Get/SetWindowLong should not be used on 64-bit systems. Doesn't really affect our usage of it, as we only use it for window styles which shouldn't be larger than a 32-bit integer, but consumers of ManagedShell may need this.