### PR TITLE
Don't use Ptr functions due to Windows 7 issues

### DIFF
--- a/src/ManagedShell.AppBar/FullScreenHelper.cs
+++ b/src/ManagedShell.AppBar/FullScreenHelper.cs
@@ -141,7 +141,7 @@ namespace ManagedShell.AppBar
                     else
                     {
                         // Still full screen but no longer active
-                        if (((int)GetWindowLongPtr(hWnd, WindowLongFlags.GWL_EXSTYLE) & (int)ExtendedWindowStyles.WS_EX_TOPMOST) == (int)ExtendedWindowStyles.WS_EX_TOPMOST)
+                        if ((GetWindowLong(hWnd, WindowLongFlags.GWL_EXSTYLE) & (int)ExtendedWindowStyles.WS_EX_TOPMOST) == (int)ExtendedWindowStyles.WS_EX_TOPMOST)
                         {
                             // If the new foreground window is a topmost window, don't consider this full-screen app inactive
                             continue;
@@ -264,8 +264,8 @@ namespace ManagedShell.AppBar
         }
 
         private Rect GetEffectiveWindowRect(IntPtr hWnd)
-        {
-            int style = (int)GetWindowLongPtr(hWnd, WindowLongFlags.GWL_STYLE);
+		{
+			int style = GetWindowLong(hWnd, WindowLongFlags.GWL_STYLE);
             Rect rect;
 
             if ((((int)WindowStyles.WS_CAPTION | (int)WindowStyles.WS_THICKFRAME) & style) == ((int)WindowStyles.WS_CAPTION | (int)WindowStyles.WS_THICKFRAME) ||

--- a/src/ManagedShell.Common/Helpers/WindowHelper.cs
+++ b/src/ManagedShell.Common/Helpers/WindowHelper.cs
@@ -103,7 +103,7 @@ namespace ManagedShell.Common.Helpers
         
         public static void HideWindowFromTasks(IntPtr hWnd)
         {
-            int style = (int)GetWindowLongPtr(hWnd, WindowLongFlags.GWL_EXSTYLE) & ~(int)ExtendedWindowStyles.WS_EX_APPWINDOW;
+            int style = GetWindowLong(hWnd, WindowLongFlags.GWL_EXSTYLE) & ~(int)ExtendedWindowStyles.WS_EX_APPWINDOW;
             if (EnvironmentHelper.IsWindows11OrBetter)
             {
                 // If the window has a Hidden Window owner, set the owner as a tool window instead so that we still receive WM_DPICHANGED on Windows 11.
@@ -121,7 +121,7 @@ namespace ManagedShell.Common.Helpers
                     GetWindowText(hwndOwner, titleBuilder, TITLE_LENGTH + 1);
                     if (titleBuilder.ToString() == "Hidden Window")
                     {
-                        SetWindowLongPtr(hwndOwner, WindowLongFlags.GWL_EXSTYLE, (IntPtr)((int)GetWindowLongPtr(hwndOwner, WindowLongFlags.GWL_EXSTYLE) | (int)ExtendedWindowStyles.WS_EX_TOOLWINDOW));
+                        SetWindowLong(hwndOwner, WindowLongFlags.GWL_EXSTYLE, (int)GetWindowLongPtr(hwndOwner, WindowLongFlags.GWL_EXSTYLE) | (int)ExtendedWindowStyles.WS_EX_TOOLWINDOW);
                     }
                 }
             }
@@ -129,7 +129,7 @@ namespace ManagedShell.Common.Helpers
             {
                 style |= (int)ExtendedWindowStyles.WS_EX_TOOLWINDOW;
             }
-            SetWindowLongPtr(hWnd, WindowLongFlags.GWL_EXSTYLE, (IntPtr)style);
+            SetWindowLong(hWnd, WindowLongFlags.GWL_EXSTYLE, style);
 
             ExcludeWindowFromPeek(hWnd);
         }

--- a/src/ManagedShell.Common/SupportingClasses/ShellWindow.cs
+++ b/src/ManagedShell.Common/SupportingClasses/ShellWindow.cs
@@ -24,9 +24,9 @@ namespace ManagedShell.Common.SupportingClasses
 
             CreateHandle(cp);
             MessageReceived += ShellWndProc;
-            NativeMethods.SetWindowLongPtr(Handle, NativeMethods.WindowLongFlags.GWL_EXSTYLE, 
-                (IntPtr)((int)NativeMethods.GetWindowLongPtr(Handle, NativeMethods.WindowLongFlags.GWL_EXSTYLE) & 
-                ~(int)NativeMethods.ExtendedWindowStyles.WS_EX_NOACTIVATE));
+            NativeMethods.SetWindowLong(Handle, NativeMethods.WindowLongFlags.GWL_EXSTYLE, 
+                NativeMethods.GetWindowLong(Handle, NativeMethods.WindowLongFlags.GWL_EXSTYLE) & 
+                ~(int)NativeMethods.ExtendedWindowStyles.WS_EX_NOACTIVATE);
 
             if (NativeMethods.SetShellWindow(Handle) == 1)
             {

--- a/src/ManagedShell.Interop/NativeMethods.User32.cs
+++ b/src/ManagedShell.Interop/NativeMethods.User32.cs
@@ -284,6 +284,11 @@ namespace ManagedShell.Interop
         [DllImport(User32_DllName, EntryPoint = "GetWindowLongPtr", SetLastError = true)]
         private static extern IntPtr GetWindowLong64(IntPtr hWnd, int nIndex);
 
+        public static int GetWindowLong(IntPtr hWnd, WindowLongFlags nIndex)
+        {
+            return GetWindowLong(hWnd, (int)nIndex);
+        }
+
         public static IntPtr GetWindowLongPtr(IntPtr hWnd, WindowLongFlags nIndex)
         {
             return GetWindowLongPtr(hWnd, (int)nIndex);
@@ -1737,6 +1742,11 @@ namespace ManagedShell.Interop
 
         [DllImport(User32_DllName, EntryPoint = "SetWindowLongPtr")]
         private static extern IntPtr SetWindowLong64(IntPtr hWnd, int nIndex, IntPtr dwNewLong);
+
+        public static int SetWindowLong(IntPtr hWnd, WindowLongFlags nIndex, int dwNewLong)
+        {
+            return SetWindowLong(hWnd, (int)nIndex, dwNewLong);
+        }
 
         public static IntPtr SetWindowLongPtr(IntPtr hWnd, WindowLongFlags nIndex, IntPtr dwNewLong)
         {

--- a/src/ManagedShell.WindowsTasks/ApplicationWindow.cs
+++ b/src/ManagedShell.WindowsTasks/ApplicationWindow.cs
@@ -338,7 +338,7 @@ namespace ManagedShell.WindowsTasks
         {
             get
             {
-                return (int)NativeMethods.GetWindowLongPtr(Handle, NativeMethods.WindowLongFlags.GWL_STYLE);
+                return NativeMethods.GetWindowLong(Handle, NativeMethods.WindowLongFlags.GWL_STYLE);
             }
         }
 
@@ -346,7 +346,7 @@ namespace ManagedShell.WindowsTasks
         {
             get
             {
-                return (int)NativeMethods.GetWindowLongPtr(Handle, NativeMethods.WindowLongFlags.GWL_EXSTYLE);
+                return NativeMethods.GetWindowLong(Handle, NativeMethods.WindowLongFlags.GWL_EXSTYLE);
             }
         }
 

--- a/src/ManagedShell.WindowsTray/TrayService.cs
+++ b/src/ManagedShell.WindowsTray/TrayService.cs
@@ -239,9 +239,9 @@ namespace ManagedShell.WindowsTray
 
                     if ((wndPos.flags & SetWindowPosFlags.SWP_SHOWWINDOW) != 0)
                     {
-                        SetWindowLongPtr(HwndTray, WindowLongFlags.GWL_STYLE,
-                            (IntPtr)((int)GetWindowLongPtr(HwndTray, WindowLongFlags.GWL_STYLE) &
-                            ~(int)WindowStyles.WS_VISIBLE));
+                        SetWindowLong(HwndTray, WindowLongFlags.GWL_STYLE,
+                            GetWindowLong(HwndTray, WindowLongFlags.GWL_STYLE) &
+                            ~(int)WindowStyles.WS_VISIBLE);
 
                         ShellLogger.Debug($"TrayService: {TrayWndClass} became visible; hiding");
                     }


### PR DESCRIPTION
It turns out Windows 7 doesn't work reliably getting styles with GetWindowLongPtr. Keep the new stuff, but go back to using the old functions for getting/setting styles to avoid issues on Windows 7.