### PR TITLE
Make Windows 11 DPI workaround optional

### DIFF
--- a/src/ManagedShell.AppBar/AppBarWindow.cs
+++ b/src/ManagedShell.AppBar/AppBarWindow.cs
@@ -136,7 +136,7 @@ namespace ManagedShell.AppBar
             PropertyChanged += AppBarWindow_PropertyChanged;
 
             ResizeMode = ResizeMode.NoResize;
-            if (EnvironmentHelper.IsWindows11OrBetter)
+            if (EnvironmentHelper.EnableWin11DpiWorkaround && EnvironmentHelper.IsWindows11OrBetter)
             {
                 // With Windows 11, we cannot use the normal way to hide from taskbar (setting as a tool window) because that breaks receiving WM_DPICHANGED.
                 ShowInTaskbar = false;

--- a/src/ManagedShell.Common/Helpers/EnvironmentHelper.cs
+++ b/src/ManagedShell.Common/Helpers/EnvironmentHelper.cs
@@ -11,6 +11,8 @@ namespace ManagedShell.Common.Helpers
         private static int osVersionMinor = 0;
         private static int osVersionBuild = 0;
 
+        public static bool EnableWin11DpiWorkaround;
+
         private static void getOSVersion()
         {
             osVersionMajor = Environment.OSVersion.Version.Major;

--- a/src/ManagedShell.Common/Helpers/WindowHelper.cs
+++ b/src/ManagedShell.Common/Helpers/WindowHelper.cs
@@ -104,7 +104,7 @@ namespace ManagedShell.Common.Helpers
         public static void HideWindowFromTasks(IntPtr hWnd)
         {
             int style = GetWindowLong(hWnd, WindowLongFlags.GWL_EXSTYLE) & ~(int)ExtendedWindowStyles.WS_EX_APPWINDOW;
-            if (EnvironmentHelper.IsWindows11OrBetter)
+            if (EnvironmentHelper.EnableWin11DpiWorkaround && EnvironmentHelper.IsWindows11OrBetter)
             {
                 // If the window has a Hidden Window owner, set the owner as a tool window instead so that we still receive WM_DPICHANGED on Windows 11.
                 // Hidden Window is the owner when ShowInTaskbar=false. Unfortunately, the window will not be hidden from Task Manager.

--- a/src/ManagedShell/ShellConfig.cs
+++ b/src/ManagedShell/ShellConfig.cs
@@ -67,7 +67,16 @@ namespace ManagedShell
         ///   - Otherwise, the string follows the format: "PathToExe:UID"
         /// </summary>
         public string[] PinnedNotifyIcons;
-        
+
         #endregion
+
+        /// <summary>
+        /// Controls whether the workaround for Windows 11 DPI change notification workaround for AppBars is enabled.<br />
+        /// <br />
+        /// In Windows 11, tool windows (which AppBars are, to hide from the taskbar, alt-tab, and Task Manager) do not receive DPI change notifications.<br />
+        /// To work around this, we can instead give the AppBar an owner window that has WS_EX_TOOLWINDOW, so the AppBar does not need it.<br />
+        /// Unfortunately, this results in the AppBar displaying in Task Manager, as well as some unpredictable Z-order issues due to the ownership relationship.
+        /// </summary>
+        public bool EnableWin11DpiWorkaround;
     }
 }

--- a/src/ManagedShell/ShellManager.cs
+++ b/src/ManagedShell/ShellManager.cs
@@ -17,7 +17,9 @@ namespace ManagedShell
             
             EnableTrayService = true,
             AutoStartTrayService = true,
-            PinnedNotifyIcons = NotificationArea.DEFAULT_PINNED
+            PinnedNotifyIcons = NotificationArea.DEFAULT_PINNED,
+
+            EnableWin11DpiWorkaround = false
         };
 
         /// <summary>
@@ -33,6 +35,8 @@ namespace ManagedShell
         /// <param name="config">A ShellConfig struct containing desired initialization parameters.</param>
         public ShellManager(ShellConfig config)
         {
+            EnvironmentHelper.EnableWin11DpiWorkaround = config.EnableWin11DpiWorkaround;
+
             if (config.EnableTrayService)
             {
                 TrayService = new TrayService();


### PR DESCRIPTION
Because the workaround has negative side-effects, make it optional and disabled by default. Shells can decide which behavior is more important for them.