### PR TITLE
Fix positioning on mixed DPI in shell mode

### DIFF
--- a/src/ManagedShell.AppBar/AppBarWindow.cs
+++ b/src/ManagedShell.AppBar/AppBarWindow.cs
@@ -569,7 +569,7 @@ namespace ManagedShell.AppBar
 
                 // if we are opening, we're getting this message as a result of positioning
                 // if we are an AppBar, that code will fix our position, so skip in that case to prevent infinite resizing.
-                if (!IsOpening || AppBarMode != AppBarMode.Normal)
+                if (!IsOpening || AppBarMode != AppBarMode.Normal || EnvironmentHelper.IsAppRunningAsShell)
                 {
                     ProcessScreenChange(ScreenSetupReason.DpiChange);
                 }


### PR DESCRIPTION
When a secondary display has a different DPI, the initial position was not correct in shell mode because AppBar logic doesn't run when in shell mode.