### PR TITLE
Refresh Explorer folder windows on shell change notifications

### DIFF
--- a/src/ManagedShell.Common/ManagedShell.Common.csproj
+++ b/src/ManagedShell.Common/ManagedShell.Common.csproj
@@ -11,6 +11,10 @@
     <PackageReference Include="System.Data.OleDb" Version="8.0.1" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'net480'">
+    <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
+
   <ItemGroup>
     <Resource Include="Resources\nullIcon.png" />
   </ItemGroup>

--- a/src/ManagedShell.Common/SupportingClasses/ExplorerRefreshWatcher.cs
+++ b/src/ManagedShell.Common/SupportingClasses/ExplorerRefreshWatcher.cs
@@ -1,0 +1,196 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Windows.Forms;
+using ManagedShell.Common.Logging;
+using static ManagedShell.Interop.NativeMethods;
+
+namespace ManagedShell.Common.SupportingClasses
+{
+    /// <summary>
+    /// Once another process registers itself as the OS shell window (via SetShellWindow, as
+    /// ShellWindow does), Explorer's own folder view windows stop receiving the shell-level
+    /// change notifications they rely on for auto-refresh, since that delivery path is
+    /// restricted to windows belonging to whichever process the OS currently trusts as "the
+    /// shell". This watcher registers for the same notifications at interrupt level, which is
+    /// not subject to that restriction, and manually refreshes any open Explorer windows
+    /// viewing an affected folder.
+    /// </summary>
+    public class ExplorerRefreshWatcher : IDisposable
+    {
+        private const SHCNE WatchedEvents = SHCNE.CREATE | SHCNE.DELETE | SHCNE.MKDIR | SHCNE.RMDIR |
+                                             SHCNE.RENAMEITEM | SHCNE.RENAMEFOLDER | SHCNE.UPDATEDIR |
+                                             SHCNE.UPDATEITEM | SHCNE.ATTRIBUTES | SHCNE.MEDIAINSERTED |
+                                             SHCNE.MEDIAREMOVED | SHCNE.DRIVEADD | SHCNE.DRIVEREMOVED;
+
+        // Events whose item pidl(s) refer to the directory whose own listing needs refreshing.
+        // Everything else (create/delete/rename an item, make/remove a subfolder, rename a
+        // subfolder) targets an item *inside* a directory, so it's that item's parent whose
+        // window needs refreshing instead.
+        private const SHCNE DirectoryTargetEvents = SHCNE.UPDATEDIR | SHCNE.MEDIAINSERTED |
+                                                      SHCNE.MEDIAREMOVED | SHCNE.DRIVEADD | SHCNE.DRIVEREMOVED;
+
+        private readonly NativeWindowEx _window;
+        private readonly int _notifyMessage;
+        private IntPtr _registration;
+        private dynamic _shellApp;
+
+        public ExplorerRefreshWatcher(NativeWindowEx window)
+        {
+            _window = window;
+            _notifyMessage = RegisterWindowMessage("ManagedShell_ExplorerRefreshWatcher");
+            _window.MessageReceived += WndProc;
+
+            SHChangeNotifyEntry entry = new SHChangeNotifyEntry
+            {
+                pIdl = IntPtr.Zero,
+                Recursively = true
+            };
+
+            _registration = SHChangeNotifyRegister(_window.Handle, SHCNRF.InterruptLevel | SHCNRF.NewDelivery,
+                WatchedEvents, (uint)_notifyMessage, 1, ref entry);
+
+            if (_registration == IntPtr.Zero)
+            {
+                ShellLogger.Warning("ExplorerRefreshWatcher: Failed to register for shell change notifications");
+            }
+        }
+
+        private void WndProc(ref Message msg, ref bool handled)
+        {
+            if (msg.Msg != _notifyMessage)
+            {
+                return;
+            }
+
+            IntPtr lockHandle = SHChangeNotification_Lock(msg.WParam, 0, out IntPtr pidlArray, out uint eventId);
+
+            if (lockHandle == IntPtr.Zero)
+            {
+                return;
+            }
+
+            try
+            {
+                bool isDirectoryTarget = (WatchedEvents & (SHCNE)eventId & DirectoryTargetEvents) != 0;
+
+                string path1 = GetPathFromPidl(Marshal.ReadIntPtr(pidlArray));
+                string path2 = GetPathFromPidl(Marshal.ReadIntPtr(pidlArray, IntPtr.Size));
+
+                string target1 = ResolveRefreshTarget(path1, isDirectoryTarget);
+                string target2 = ResolveRefreshTarget(path2, isDirectoryTarget);
+
+                if (!string.IsNullOrEmpty(target1) || !string.IsNullOrEmpty(target2))
+                {
+                    RefreshExplorerWindows(target1, target2);
+                }
+            }
+            catch (Exception ex)
+            {
+                ShellLogger.Warning("ExplorerRefreshWatcher: Error handling shell change notification", ex);
+            }
+            finally
+            {
+                SHChangeNotification_Unlock(lockHandle);
+            }
+        }
+
+        private static string GetPathFromPidl(IntPtr pidl)
+        {
+            if (pidl == IntPtr.Zero)
+            {
+                return null;
+            }
+
+            StringBuilder path = new StringBuilder(260);
+            return SHGetPathFromIDList(pidl, path) ? path.ToString() : null;
+        }
+
+        // For events where the pidl refers to an item inside a directory (create/delete/rename
+        // a file, make/remove/rename a subfolder), the Explorer window that needs refreshing is
+        // the one browsing that item's parent, not the item's own path.
+        private static string ResolveRefreshTarget(string path, bool isDirectoryTarget)
+        {
+            if (string.IsNullOrEmpty(path))
+            {
+                return null;
+            }
+
+            if (isDirectoryTarget)
+            {
+                return path;
+            }
+
+            try
+            {
+                return System.IO.Path.GetDirectoryName(path);
+            }
+            catch (ArgumentException)
+            {
+                return null;
+            }
+        }
+
+        private void RefreshExplorerWindows(string target1, string target2)
+        {
+            try
+            {
+                _shellApp ??= Activator.CreateInstance(Type.GetTypeFromProgID("Shell.Application"));
+                dynamic windows = _shellApp.Windows();
+
+                foreach (dynamic window in windows)
+                {
+                    try
+                    {
+                        string windowPath = window?.Document?.Folder?.Self?.Path as string;
+
+                        if (!string.IsNullOrEmpty(windowPath) && (PathsMatch(windowPath, target1) || PathsMatch(windowPath, target2)))
+                        {
+                            window.Refresh();
+                        }
+                    }
+                    catch (COMException)
+                    {
+                        // window doesn't expose a Document/Folder (e.g. an IE window), skip it
+                    }
+                    finally
+                    {
+                        if (window != null)
+                        {
+                            Marshal.ReleaseComObject(window);
+                        }
+                    }
+                }
+
+                Marshal.ReleaseComObject(windows);
+            }
+            catch (Exception ex)
+            {
+                ShellLogger.Warning("ExplorerRefreshWatcher: Unable to refresh Explorer windows", ex);
+            }
+        }
+
+        private static bool PathsMatch(string windowPath, string target)
+        {
+            return !string.IsNullOrEmpty(target) &&
+                   string.Equals(windowPath.TrimEnd('\\'), target.TrimEnd('\\'), StringComparison.OrdinalIgnoreCase);
+        }
+
+        public void Dispose()
+        {
+            _window.MessageReceived -= WndProc;
+
+            if (_registration != IntPtr.Zero)
+            {
+                SHChangeNotifyDeregister(_registration);
+                _registration = IntPtr.Zero;
+            }
+
+            if (_shellApp != null)
+            {
+                Marshal.ReleaseComObject(_shellApp);
+                _shellApp = null;
+            }
+        }
+    }
+}

--- a/src/ManagedShell.Common/SupportingClasses/ExplorerRefreshWatcher.cs
+++ b/src/ManagedShell.Common/SupportingClasses/ExplorerRefreshWatcher.cs
@@ -8,13 +8,15 @@ using static ManagedShell.Interop.NativeMethods;
 namespace ManagedShell.Common.SupportingClasses
 {
     /// <summary>
-    /// Once another process registers itself as the OS shell window (via SetShellWindow, as
-    /// ShellWindow does), Explorer's own folder view windows stop receiving the shell-level
-    /// change notifications they rely on for auto-refresh, since that delivery path is
-    /// restricted to windows belonging to whichever process the OS currently trusts as "the
-    /// shell". This watcher registers for the same notifications at interrupt level, which is
-    /// not subject to that restriction, and manually refreshes any open Explorer windows
-    /// viewing an affected folder.
+    /// Once ShellWindow registers itself as the OS shell window (via SetShellWindow), Explorer's
+    /// own folder view windows stop receiving the SHCNRF_ShellLevel change notifications they
+    /// rely on for auto-refresh. The exact reason isn't documented, but it's reproducible and
+    /// scoped specifically to SetShellWindow (confirmed against cairoshell/cairoshell#434) — the
+    /// working theory is that shell-level delivery is restricted to windows belonging to
+    /// whichever process the OS currently considers "the shell". SHCNRF_InterruptLevel
+    /// notifications (meant for background/service-style listeners) aren't subject to whatever
+    /// that restriction is, so this watcher registers for those instead and manually refreshes
+    /// any open Explorer window viewing an affected folder.
     /// </summary>
     public class ExplorerRefreshWatcher : IDisposable
     {
@@ -32,7 +34,7 @@ namespace ManagedShell.Common.SupportingClasses
 
         private readonly NativeWindowEx _window;
         private readonly int _notifyMessage;
-        private IntPtr _registration;
+        private uint _registration;
         private dynamic _shellApp;
 
         public ExplorerRefreshWatcher(NativeWindowEx window)
@@ -50,7 +52,7 @@ namespace ManagedShell.Common.SupportingClasses
             _registration = SHChangeNotifyRegister(_window.Handle, SHCNRF.InterruptLevel | SHCNRF.NewDelivery,
                 WatchedEvents, (uint)_notifyMessage, 1, ref entry);
 
-            if (_registration == IntPtr.Zero)
+            if (_registration == 0)
             {
                 ShellLogger.Warning("ExplorerRefreshWatcher: Failed to register for shell change notifications");
             }
@@ -63,7 +65,9 @@ namespace ManagedShell.Common.SupportingClasses
                 return;
             }
 
-            IntPtr lockHandle = SHChangeNotification_Lock(msg.WParam, 0, out IntPtr pidlArray, out uint eventId);
+            // Registered with SHCNRF_NewDelivery, so per SHChangeNotification_Lock's documented
+            // contract, wParam/lParam from the message map to its hChange/dwProcId parameters.
+            IntPtr lockHandle = SHChangeNotification_Lock(msg.WParam, unchecked((int)(long)msg.LParam), out IntPtr pidlArray, out uint eventId);
 
             if (lockHandle == IntPtr.Zero)
             {
@@ -180,10 +184,10 @@ namespace ManagedShell.Common.SupportingClasses
         {
             _window.MessageReceived -= WndProc;
 
-            if (_registration != IntPtr.Zero)
+            if (_registration != 0)
             {
                 SHChangeNotifyDeregister(_registration);
-                _registration = IntPtr.Zero;
+                _registration = 0;
             }
 
             if (_shellApp != null)

--- a/src/ManagedShell.Common/SupportingClasses/ShellWindow.cs
+++ b/src/ManagedShell.Common/SupportingClasses/ShellWindow.cs
@@ -10,6 +10,8 @@ namespace ManagedShell.Common.SupportingClasses
         public EventHandler WallpaperChanged;
         public EventHandler WorkAreaChanged;
 
+        private ExplorerRefreshWatcher _explorerRefreshWatcher;
+
         public ShellWindow()
         {
             CreateParams cp = new CreateParams();
@@ -32,18 +34,26 @@ namespace ManagedShell.Common.SupportingClasses
             {
                 // we did it
                 IsShellWindow = true;
+
+                // Becoming the shell window breaks Explorer's own folder-view auto-refresh, since
+                // shell-level change notifications are only delivered to the trusted shell process.
+                // Work around that by relaying notifications to open Explorer windows ourselves.
+                _explorerRefreshWatcher = new ExplorerRefreshWatcher(this);
             }
         }
 
         public void SetSize()
         {
-            NativeMethods.SetWindowPos(Handle, IntPtr.Zero, SystemInformation.VirtualScreen.Left, 
-                SystemInformation.VirtualScreen.Top, SystemInformation.VirtualScreen.Width, SystemInformation.VirtualScreen.Height, 
+            NativeMethods.SetWindowPos(Handle, IntPtr.Zero, SystemInformation.VirtualScreen.Left,
+                SystemInformation.VirtualScreen.Top, SystemInformation.VirtualScreen.Width, SystemInformation.VirtualScreen.Height,
                 (int)NativeMethods.SetWindowPosFlags.SWP_NOZORDER | (int)NativeMethods.SetWindowPosFlags.SWP_NOACTIVATE);
         }
 
         public void Dispose()
         {
+            _explorerRefreshWatcher?.Dispose();
+            _explorerRefreshWatcher = null;
+
             NativeMethods.DestroyWindow(Handle);
         }
 

--- a/src/ManagedShell.Interop/NativeMethods.Shell32.cs
+++ b/src/ManagedShell.Interop/NativeMethods.Shell32.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Text;
 
 namespace ManagedShell.Interop
 {
@@ -696,5 +697,90 @@ namespace ManagedShell.Interop
             NoAppcontainerRedirection = 0x00010000,
             AliasOnly = 0x80000000
         }
+
+        #region Shell change notifications (SHChangeNotifyRegister)
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct SHChangeNotifyEntry
+        {
+            public IntPtr pIdl;
+            [MarshalAs(UnmanagedType.Bool)]
+            public bool Recursively;
+        }
+
+        [Flags]
+        public enum SHCNRF : uint
+        {
+            InterruptLevel = 0x0001,
+            ShellLevel = 0x0002,
+            RecursiveInterrupt = 0x1000,
+            NewDelivery = 0x8000
+        }
+
+        [Flags]
+        public enum SHCNE : long
+        {
+            RENAMEITEM = 0x00000001L,
+            CREATE = 0x00000002L,
+            DELETE = 0x00000004L,
+            MKDIR = 0x00000008L,
+            RMDIR = 0x00000010L,
+            MEDIAINSERTED = 0x00000020L,
+            MEDIAREMOVED = 0x00000040L,
+            DRIVEREMOVED = 0x00000080L,
+            DRIVEADD = 0x00000100L,
+            NETSHARE = 0x00000200L,
+            NETUNSHARE = 0x00000400L,
+            ATTRIBUTES = 0x00000800L,
+            UPDATEDIR = 0x00001000L,
+            UPDATEITEM = 0x00002000L,
+            SERVERDISCONNECT = 0x00004000L,
+            UPDATEIMAGE = 0x00008000L,
+            DRIVEADDGUI = 0x00010000L,
+            RENAMEFOLDER = 0x00020000L,
+            FREESPACE = 0x00040000L,
+            EXTENDED_EVENT = 0x04000000L,
+            ASSOCCHANGED = 0x08000000L,
+            DISKEVENTS = 0x0002381FL,
+            GLOBALEVENTS = 0x0C0581E0L,
+            ALLEVENTS = 0x7FFFFFFFL,
+            INTERRUPT = unchecked((long)0x80000000L)
+        }
+
+        [Flags]
+        public enum SHCNF : uint
+        {
+            IDLIST = 0x0000,
+            PATHA = 0x0001,
+            PRINTERA = 0x0002,
+            DWORD = 0x0003,
+            PATHW = 0x0005,
+            PRINTERW = 0x0006,
+            TYPE = 0x00FF,
+            FLUSH = 0x1000,
+            FLUSHNOWAIT = 0x2000
+        }
+
+        // Registers a window to receive shell change notifications. Using SHCNRF_InterruptLevel
+        // (rather than SHCNRF_ShellLevel) avoids the OS's "trusted shell process" delivery
+        // restriction that normal shell-level listeners are subject to.
+        [DllImport(Shell32_DllName, CharSet = CharSet.Auto)]
+        public static extern IntPtr SHChangeNotifyRegister(IntPtr hWnd, SHCNRF fSources, SHCNE fEvents, uint wMsg, int cEntries, ref SHChangeNotifyEntry pFsne);
+
+        [DllImport(Shell32_DllName)]
+        public static extern bool SHChangeNotifyDeregister(IntPtr hNotify);
+
+        // Undocumented, ordinal-exported helpers used to decode the shared-memory payload
+        // delivered with the registered notification window message.
+        [DllImport(Shell32_DllName, EntryPoint = "#644")]
+        public static extern IntPtr SHChangeNotification_Lock(IntPtr wParam, int dwProcessId, out IntPtr pidlArray, out uint lEvent);
+
+        [DllImport(Shell32_DllName, EntryPoint = "#645")]
+        public static extern bool SHChangeNotification_Unlock(IntPtr hLock);
+
+        [DllImport(Shell32_DllName, CharSet = CharSet.Auto)]
+        public static extern bool SHGetPathFromIDList(IntPtr pidl, StringBuilder pszPath);
+
+        #endregion
     }
 }

--- a/src/ManagedShell.Interop/NativeMethods.Shell32.cs
+++ b/src/ManagedShell.Interop/NativeMethods.Shell32.cs
@@ -717,34 +717,36 @@ namespace ManagedShell.Interop
             NewDelivery = 0x8000
         }
 
+        // Underlying type is int to match the native fEvents parameter, which is LONG
+        // (32-bit) per SHChangeNotifyRegister's documented signature.
         [Flags]
-        public enum SHCNE : long
+        public enum SHCNE
         {
-            RENAMEITEM = 0x00000001L,
-            CREATE = 0x00000002L,
-            DELETE = 0x00000004L,
-            MKDIR = 0x00000008L,
-            RMDIR = 0x00000010L,
-            MEDIAINSERTED = 0x00000020L,
-            MEDIAREMOVED = 0x00000040L,
-            DRIVEREMOVED = 0x00000080L,
-            DRIVEADD = 0x00000100L,
-            NETSHARE = 0x00000200L,
-            NETUNSHARE = 0x00000400L,
-            ATTRIBUTES = 0x00000800L,
-            UPDATEDIR = 0x00001000L,
-            UPDATEITEM = 0x00002000L,
-            SERVERDISCONNECT = 0x00004000L,
-            UPDATEIMAGE = 0x00008000L,
-            DRIVEADDGUI = 0x00010000L,
-            RENAMEFOLDER = 0x00020000L,
-            FREESPACE = 0x00040000L,
-            EXTENDED_EVENT = 0x04000000L,
-            ASSOCCHANGED = 0x08000000L,
-            DISKEVENTS = 0x0002381FL,
-            GLOBALEVENTS = 0x0C0581E0L,
-            ALLEVENTS = 0x7FFFFFFFL,
-            INTERRUPT = unchecked((long)0x80000000L)
+            RENAMEITEM = 0x00000001,
+            CREATE = 0x00000002,
+            DELETE = 0x00000004,
+            MKDIR = 0x00000008,
+            RMDIR = 0x00000010,
+            MEDIAINSERTED = 0x00000020,
+            MEDIAREMOVED = 0x00000040,
+            DRIVEREMOVED = 0x00000080,
+            DRIVEADD = 0x00000100,
+            NETSHARE = 0x00000200,
+            NETUNSHARE = 0x00000400,
+            ATTRIBUTES = 0x00000800,
+            UPDATEDIR = 0x00001000,
+            UPDATEITEM = 0x00002000,
+            SERVERDISCONNECT = 0x00004000,
+            UPDATEIMAGE = 0x00008000,
+            DRIVEADDGUI = 0x00010000,
+            RENAMEFOLDER = 0x00020000,
+            FREESPACE = 0x00040000,
+            EXTENDED_EVENT = 0x04000000,
+            ASSOCCHANGED = 0x08000000,
+            DISKEVENTS = 0x0002381F,
+            GLOBALEVENTS = 0x0C0581E0,
+            ALLEVENTS = 0x7FFFFFFF,
+            INTERRUPT = unchecked((int)0x80000000)
         }
 
         [Flags]
@@ -761,14 +763,15 @@ namespace ManagedShell.Interop
             FLUSHNOWAIT = 0x2000
         }
 
-        // Registers a window to receive shell change notifications. Using SHCNRF_InterruptLevel
-        // (rather than SHCNRF_ShellLevel) avoids the OS's "trusted shell process" delivery
-        // restriction that normal shell-level listeners are subject to.
+        // Registers a window to receive shell change notifications. SHCNRF_InterruptLevel
+        // notifications are not restricted to Explorer's own folder views the way
+        // SHCNRF_ShellLevel notifications appear to be in practice (see ExplorerRefreshWatcher).
+        // Return value is a ULONG registration ID, not a handle.
         [DllImport(Shell32_DllName, CharSet = CharSet.Auto)]
-        public static extern IntPtr SHChangeNotifyRegister(IntPtr hWnd, SHCNRF fSources, SHCNE fEvents, uint wMsg, int cEntries, ref SHChangeNotifyEntry pFsne);
+        public static extern uint SHChangeNotifyRegister(IntPtr hWnd, SHCNRF fSources, SHCNE fEvents, uint wMsg, int cEntries, ref SHChangeNotifyEntry pFsne);
 
         [DllImport(Shell32_DllName)]
-        public static extern bool SHChangeNotifyDeregister(IntPtr hNotify);
+        public static extern bool SHChangeNotifyDeregister(uint ulID);
 
         // Decodes the shared-memory payload delivered with the registered notification window
         // message. Documented in shlobj_core.h (see SHChangeNotification_Lock/_Unlock on

--- a/src/ManagedShell.Interop/NativeMethods.Shell32.cs
+++ b/src/ManagedShell.Interop/NativeMethods.Shell32.cs
@@ -770,12 +770,13 @@ namespace ManagedShell.Interop
         [DllImport(Shell32_DllName)]
         public static extern bool SHChangeNotifyDeregister(IntPtr hNotify);
 
-        // Undocumented, ordinal-exported helpers used to decode the shared-memory payload
-        // delivered with the registered notification window message.
-        [DllImport(Shell32_DllName, EntryPoint = "#644")]
-        public static extern IntPtr SHChangeNotification_Lock(IntPtr wParam, int dwProcessId, out IntPtr pidlArray, out uint lEvent);
+        // Decodes the shared-memory payload delivered with the registered notification window
+        // message. Documented in shlobj_core.h (see SHChangeNotification_Lock/_Unlock on
+        // Microsoft Learn); Shell32.dll has exported these by name since Windows 10.
+        [DllImport(Shell32_DllName)]
+        public static extern IntPtr SHChangeNotification_Lock(IntPtr hChange, int dwProcId, out IntPtr pidlArray, out uint lEvent);
 
-        [DllImport(Shell32_DllName, EntryPoint = "#645")]
+        [DllImport(Shell32_DllName)]
         public static extern bool SHChangeNotification_Unlock(IntPtr hLock);
 
         [DllImport(Shell32_DllName, CharSet = CharSet.Auto)]


### PR DESCRIPTION
Fixes #434 — Explorer folder windows stop auto-refreshing (create/rename/copy/delete require a manual F5) whenever Cairo is running as the shell.

## Testing
- [x] Manually verified against a local Cairo build with Cairo set as shell:
  - [x] Create file/folder — appears without F5
  - [x] Rename file — new name shows immediately
  - [x] Copy/paste into folder — appears immediately
  - [x] Delete file — disappears immediately
  - [x] Move file between two open Explorer windows — both update